### PR TITLE
Update `master`

### DIFF
--- a/.github/workflows/test-cpp-static.yml
+++ b/.github/workflows/test-cpp-static.yml
@@ -2,8 +2,7 @@ name: Test cpp-static
 
 on:
   push:
-    branches:
-      - master
+    branches: [master, dev]
   pull_request:
 
 jobs:

--- a/.github/workflows/test-cs.yml
+++ b/.github/workflows/test-cs.yml
@@ -2,8 +2,7 @@ name: Test cs
 
 on:
   push:
-    branches:
-      - master
+    branches: [master, dev]
   pull_request:
 
 jobs:

--- a/.github/workflows/test-eval.yml
+++ b/.github/workflows/test-eval.yml
@@ -1,0 +1,108 @@
+name: Test eval
+
+on:
+  push:
+    branches: [master, dev]
+  pull_request:
+
+jobs:
+  # from https://github.com/HaxeFoundation/haxe/blob/development/.github/workflows/main.yml
+  # TODO: use https://github.com/ocaml/setup-ocaml for ocaml/opam (for caching)
+  test-eval-mac:
+    runs-on: macos-latest
+    env:
+      PLATFORM: mac
+      OPAMYES: 1
+    steps:
+
+    - name: Checkout Haxe
+      uses: actions/checkout@v2
+      with:
+        repository: HaxeFoundation/haxe
+        submodules: recursive
+        path: "haxe"
+
+    - name: Checkout ammer-core
+      uses: actions/checkout@v2
+      with:
+        path: "ammer-core"
+
+    - name: Install Neko from S3
+      run: |
+        set -ex
+        curl -sSL https://build.haxe.org/builds/neko/$PLATFORM/neko_latest.tar.gz -o $RUNNER_TEMP/neko_latest.tar.gz
+        tar -xf $RUNNER_TEMP/neko_latest.tar.gz -C $RUNNER_TEMP
+        NEKOPATH=`echo $RUNNER_TEMP/neko-*-*`
+        sudo mkdir -p /usr/local/bin
+        sudo mkdir -p /usr/local/lib/neko
+        sudo ln -s $NEKOPATH/{neko,nekoc,nekoml,nekotools}  /usr/local/bin/
+        sudo ln -s $NEKOPATH/libneko.*                      /usr/local/lib/
+        sudo ln -s $NEKOPATH/*.ndll                         /usr/local/lib/neko/
+        echo "NEKOPATH=$NEKOPATH" >> $GITHUB_ENV
+
+    - name: Install dependencies
+      env:
+        ZLIB_VERSION: 1.2.12
+        MBEDTLS_VERSION: 2.25.0
+        PCRE_VERSION: 10.39
+      run: |
+        cd haxe
+        set -ex
+        brew uninstall openssl@1.0.2t || echo
+        brew uninstall python@2.7.17 || echo
+        brew untap local/openssl || echo
+        brew untap local/python2 || echo
+        brew update
+        # brew unlink python@2
+        brew bundle --file=tests/Brewfile --no-upgrade || brew link --overwrite awscli
+        brew install cpanminus
+        cpanm IPC::System::Simple
+        cpanm String::ShellQuote
+        curl -L https://www.zlib.net/zlib-$ZLIB_VERSION.tar.gz | tar xz
+        cd zlib-$ZLIB_VERSION
+        ./configure
+        make && make install
+        curl -L https://github.com/ARMmbed/mbedtls/archive/v$MBEDTLS_VERSION.tar.gz | tar xz
+        cd mbedtls-$MBEDTLS_VERSION
+        make && make install
+        curl -L https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.39/pcre2-$PCRE_VERSION.tar.gz | tar xz
+        cd pcre2-$PCRE_VERSION
+        ./configure --enable-utf8 --enable-pcre2-8 --enable-pcre2-16 --enable-pcre2-32 --enable-unicode-properties --enable-pcregrep-libz --enable-pcregrep-libbz2 --enable-jit
+        make && make install
+
+    - name: Install OCaml libraries
+      run: |
+        cd haxe
+        set -ex
+        opam init # --disable-sandboxing
+        opam update
+        opam switch create 4.07.1
+        eval $(opam env)
+        opam env
+        opam pin add ctypes 0.17.1 --yes
+        opam pin add haxe . --no-action
+        opam install haxe --deps-only --assume-depexts
+        opam list
+        ocamlopt -v
+
+    - name: Build Haxe
+      run: |
+        cd haxe
+        set -ex
+        eval $(opam env)
+        opam config exec -- make -s -j`sysctl -n hw.ncpu` STATICLINK=1 "LIB_PARAMS=/usr/local/lib/libz.a /usr/local/lib/libpcre.a /usr/local/lib/libmbedtls.a /usr/local/lib/libmbedcrypto.a /usr/local/lib/libmbedx509.a -cclib '-framework Security -framework CoreFoundation'" haxe
+        opam config exec -- make -s haxelib
+        make -s install
+        echo "HAXE_PATH=`pwd`" >> $GITHUB_ENV
+
+    - name: Set up haxelibs
+      shell: bash
+      run: |
+        haxelib setup ~/haxelib
+        haxelib dev ammer-core ammer-core
+
+    - name: Run tests
+      run: |
+        cd ammer-core/test
+        eval $(opam env)
+        haxe -D ammercoretest.eval.haxerepopath="$HAXE_PATH" build/build-eval.hxml

--- a/.github/workflows/test-hl.yml
+++ b/.github/workflows/test-hl.yml
@@ -2,8 +2,7 @@ name: Test hl, hlc
 
 on:
   push:
-    branches:
-      - master
+    branches: [master, dev]
   pull_request:
 
 jobs:

--- a/.github/workflows/test-hl.yml
+++ b/.github/workflows/test-hl.yml
@@ -122,15 +122,16 @@ jobs:
         rm /usr/bin/link
         cd ammer-core/test
         mkdir -p bin/hlc
+        cp "$HASHLINK_PATH/libhl.dll" bin/hlc
         cp "$HASHLINK_PATH/libhl.lib" bin/hlc
         haxe -D ammercoretest.hl.includepaths="$HASHLINK_PATH/include" -D ammercoretest.hl.librarypaths="$HASHLINK_PATH" build/build-hl.hxml
         haxe -D ammercoretest.hl.includepaths="$HASHLINK_PATH/include" -D ammercoretest.hl.librarypaths="$HASHLINK_PATH" build/build-hlc.hxml
 
-    #- name: Compile tests (MSVC)
-    #  if: matrix.os == 'windows-latest'
-    #  run: |
-    #    cd ammer-core/test/bin/hlc
-    #    cl.exe /DLIBHL_EXPORTS /Femain.exe /I"$env:HASHLINK_PATH_WIN\include" /I. libhl.lib lib.hl.lib main.c /link /VERBOSE /SUBSYSTEM:CONSOLE /LIBPATH:"." /LIBPATH:"ammer_build\example"
+    - name: Compile tests (MSVC)
+      if: matrix.os == 'windows-latest'
+      run: |
+        cd ammer-core/test/bin/hlc
+        cl.exe /Femain.exe /I"$env:HASHLINK_PATH_WIN\include" /I. libhl.lib libexample.lib main.c /link /SUBSYSTEM:CONSOLE /LIBPATH:"."
 
     - name: Run tests (Linux)
       if: matrix.os == 'ubuntu-latest'
@@ -146,11 +147,10 @@ jobs:
         test/test-hl-macos.sh
         test/test-hlc-macos.sh
 
-    # TODO: compile + run HL/C (issue #12)
     - name: Run tests (Windows)
       if: matrix.os == 'windows-latest'
       shell: bash
       run: |
         cd ammer-core/test
         test/test-hl-windows.sh
-      #test/test-hlc-windows.sh
+        test/test-hlc-windows.sh

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -2,8 +2,7 @@ name: Test java, jvm
 
 on:
   push:
-    branches:
-      - master
+    branches: [master, dev]
   pull_request:
 
 jobs:

--- a/.github/workflows/test-lua.yml
+++ b/.github/workflows/test-lua.yml
@@ -2,8 +2,7 @@ name: Test lua
 
 on:
   push:
-    branches:
-      - master
+    branches: [master, dev]
   pull_request:
 
 jobs:

--- a/.github/workflows/test-neko.yml
+++ b/.github/workflows/test-neko.yml
@@ -2,8 +2,7 @@ name: Test neko
 
 on:
   push:
-    branches:
-      - master
+    branches: [master, dev]
   pull_request:
 
 jobs:

--- a/.github/workflows/test-nodejs.yml
+++ b/.github/workflows/test-nodejs.yml
@@ -2,8 +2,7 @@ name: Test nodejs
 
 on:
   push:
-    branches:
-      - master
+    branches: [master, dev]
   pull_request:
 
 jobs:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -59,8 +59,11 @@ jobs:
     - name: Compile tests (macOS)
       if: matrix.os == 'macos-latest'
       run: |
+        python3-config --cflags
+        python3-config --ldflags
+        python3-config --libs
         cd ammer-core/test
-        haxe -D ammercoretest.python.includepaths=/usr/local/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/include/python3.9 -D ammercoretest.python.librarypaths=/usr/local/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/config-3.9-darwin -D ammercoretest.python.version=9 build/build-python.hxml
+        haxe -D ammercoretest.python.includepaths=/usr/local/opt/python@3.10/Frameworks/Python.framework/Versions/3.10/include/python3.10 -D ammercoretest.python.librarypaths=/usr/local/opt/python@3.10/Frameworks/Python.framework/Versions/3.10/lib/python3.10/config-3.10-darwin -D ammercoretest.python.version=10 build/build-python.hxml
 
     - name: Compile tests (Windows)
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -2,8 +2,7 @@ name: Test python
 
 on:
   push:
-    branches:
-      - master
+    branches: [master, dev]
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@
 
 Documentation coming soon.
 
-| Target | Linux | macOS | Windows | CI status |
-| ------ | ----- | ----- | ------- | ----- |
-| `cpp-static` | ✔️ | ✔️ | ✔️ | [![](https://github.com/Aurel300/ammer-core/actions/workflows/test-cpp-static.yml/badge.svg)](https://github.com/Aurel300/ammer-core/actions/workflows/test-cpp-static.yml) |
-| `cs` | ✔️ | ✔️ | #11 | [![](https://github.com/Aurel300/ammer-core/actions/workflows/test-cs.yml/badge.svg)](https://github.com/Aurel300/ammer-core/actions/workflows/test-cs.yml) |
-| `hl`, `hlc` | ✔️ | ✔️ | #12 | [![](https://github.com/Aurel300/ammer-core/actions/workflows/test-hl.yml/badge.svg)](https://github.com/Aurel300/ammer-core/actions/workflows/test-hl.yml) |
-| `java`, `jvm` | ✔️ | ✔️ | ✔️ | [![](https://github.com/Aurel300/ammer-core/actions/workflows/test-java.yml/badge.svg)](https://github.com/Aurel300/ammer-core/actions/workflows/test-java.yml) |
-| `lua` | ✔️ | ✔️ | #13 | [![](https://github.com/Aurel300/ammer-core/actions/workflows/test-lua.yml/badge.svg)](https://github.com/Aurel300/ammer-core/actions/workflows/test-lua.yml) |
-| `neko` | ✔️ | ✔️ | ✔️ | [![](https://github.com/Aurel300/ammer-core/actions/workflows/test-neko.yml/badge.svg)](https://github.com/Aurel300/ammer-core/actions/workflows/test-neko.yml) |
-| `nodejs` | ✔️ | ✔️ | ✔️ | [![](https://github.com/Aurel300/ammer-core/actions/workflows/test-nodejs.yml/badge.svg)](https://github.com/Aurel300/ammer-core/actions/workflows/test-nodejs.yml) |
-| `python` | ✔️ | ✔️ | ✔️ | [![](https://github.com/Aurel300/ammer-core/actions/workflows/test-python.yml/badge.svg)](https://github.com/Aurel300/ammer-core/actions/workflows/test-python.yml) |
+| Target        | Linux | macOS | Windows | CI status |
+| ------------- |:-----:|:-----:|:-------:| ---------:|
+| `cpp-static`  | ✔️     | ✔️     | ✔️       | [![](https://github.com/Aurel300/ammer-core/actions/workflows/test-cpp-static.yml/badge.svg)](https://github.com/Aurel300/ammer-core/actions/workflows/test-cpp-static.yml) |
+| `cs`          | ✔️     | ✔️     | [#11](https://github.com/Aurel300/ammer-core/issues/11) | [![](https://github.com/Aurel300/ammer-core/actions/workflows/test-cs.yml/badge.svg)](https://github.com/Aurel300/ammer-core/actions/workflows/test-cs.yml) |
+| `eval`        | -     | ✔️     | -       | [![](https://github.com/Aurel300/ammer-core/actions/workflows/test-eval.yml/badge.svg)](https://github.com/Aurel300/ammer-core/actions/workflows/test-eval.yml) |
+| `hl`, `hlc`   | ✔️     | ✔️     | ✔️       | [![](https://github.com/Aurel300/ammer-core/actions/workflows/test-hl.yml/badge.svg)](https://github.com/Aurel300/ammer-core/actions/workflows/test-hl.yml) |
+| `java`, `jvm` | ✔️     | ✔️     | ✔️       | [![](https://github.com/Aurel300/ammer-core/actions/workflows/test-java.yml/badge.svg)](https://github.com/Aurel300/ammer-core/actions/workflows/test-java.yml) |
+| `lua`         | ✔️     | ✔️     | [#13](https://github.com/Aurel300/ammer-core/issues/13) | [![](https://github.com/Aurel300/ammer-core/actions/workflows/test-lua.yml/badge.svg)](https://github.com/Aurel300/ammer-core/actions/workflows/test-lua.yml) |
+| `neko`        | ✔️     | ✔️     | ✔️       | [![](https://github.com/Aurel300/ammer-core/actions/workflows/test-neko.yml/badge.svg)](https://github.com/Aurel300/ammer-core/actions/workflows/test-neko.yml) |
+| `nodejs`      | ✔️     | ✔️     | ✔️       | [![](https://github.com/Aurel300/ammer-core/actions/workflows/test-nodejs.yml/badge.svg)](https://github.com/Aurel300/ammer-core/actions/workflows/test-nodejs.yml) |
+| `python`      | ✔️     | ✔️     | ✔️       | [![](https://github.com/Aurel300/ammer-core/actions/workflows/test-python.yml/badge.svg)](https://github.com/Aurel300/ammer-core/actions/workflows/test-python.yml) |

--- a/src/ammer/core/BuildOp.hx
+++ b/src/ammer/core/BuildOp.hx
@@ -1,7 +1,5 @@
 package ammer.core;
 
-import ammer.core.LibraryConfig.LibraryAbi;
-
 enum BuildOp {
   BOCwd(
     path:String,
@@ -35,8 +33,8 @@ enum BuildOpCommand {
   Copy;
   WriteContent(_:String);
   WriteData(_:haxe.io.Bytes);
-  CompileObject(abi:LibraryAbi, opt:MakeCompileOptions);
-  LinkLibrary(abi:LibraryAbi, opt:MakeLinkOptions);
+  CompileObject(lang:LibraryLanguage, opt:MakeCompileOptions);
+  LinkLibrary(lang:LibraryLanguage, opt:MakeLinkOptions);
   EnsureDirectory;
   Command(cmd:String, args:Array<String>);
 }

--- a/src/ammer/core/BuildOp.hx
+++ b/src/ammer/core/BuildOp.hx
@@ -48,5 +48,7 @@ typedef MakeLinkOptions = {
   defines:Array<String>,
   libraryPaths:Array<String>,
   libraries:Array<String>,
+  linkName:String,
+  ?frameworks:Array<String>,
   ?staticLibraries:Array<String>,
 };

--- a/src/ammer/core/BuildOp.hx
+++ b/src/ammer/core/BuildOp.hx
@@ -40,6 +40,7 @@ enum BuildOpCommand {
 }
 
 typedef MakeCompileOptions = {
+  defines:Array<String>,
   includePaths:Array<String>,
 };
 

--- a/src/ammer/core/BuildProgram.hx
+++ b/src/ammer/core/BuildProgram.hx
@@ -127,6 +127,9 @@ class BuildProgram {
         } else {
           var args = ["-m64", "-o", extensions(dst)];
           if (Sys.systemName() == "Mac") {
+            // TODO: make install_name configurable (e.g. @rpath/../etc)
+            args.push("-install_name");
+            args.push('@executable_path/${extensions(opt.linkName)}');
             args.push("-dynamiclib");
           } else {
             args.push("-shared");
@@ -139,6 +142,13 @@ class BuildProgram {
           }
           for (path in opt.libraryPaths)
             args.push('-L$path');
+          if (opt.frameworks != null) {
+            // TODO: emit warning or error when not used on Mac
+            for (framework in opt.frameworks) {
+              args.push("-framework");
+              args.push(framework);
+            }
+          }
           if (opt.staticLibraries != null) {
             if (Sys.systemName() == "Mac") {
               // TODO: mixing dynamic and static linking on Mac

--- a/src/ammer/core/BuildProgram.hx
+++ b/src/ammer/core/BuildProgram.hx
@@ -84,7 +84,7 @@ class BuildProgram {
       case [File(dst), _, WriteData(data)]:
         Sys.println('write $dst');
         sys.io.File.saveBytes(extensions(dst), data);
-      case [File(dst), File(src), CompileObject(abi, opt)]:
+      case [File(dst), File(src), CompileObject(lang, opt)]:
         if (useMSVC) {
           var args = [];
           for (path in opt.includePaths) {
@@ -95,17 +95,17 @@ class BuildProgram {
           run("cl.exe", args);
         } else {
           var args = ["-fPIC", "-o", extensions(dst), "-c", extensions(src)];
-          if (abi == Cpp || abi == ObjectiveCpp) {
+          if (lang == Cpp || lang == ObjectiveCpp) {
             args.push("-std=c++11");
           }
           for (path in opt.includePaths) {
             args.push("-I");
             args.push(path);
           }
-          run(abi.match(Cpp | ObjectiveCpp) ? "g++" : "cc", args);
+          run(lang.match(Cpp | ObjectiveCpp) ? "g++" : "cc", args);
         }
       case [_, _, CompileObject(_)]: throw "invalid CompileObject command";
-      case [File(dst), File(src), LinkLibrary(abi, opt)]:
+      case [File(dst), File(src), LinkLibrary(lang, opt)]:
         if (useMSVC) {
           var args = ['/Fe${extensions(dst)}', "/LD", extensions(src)];
           for (d in opt.defines) {
@@ -147,7 +147,7 @@ class BuildProgram {
           }
           for (lib in opt.libraries)
             args.push('-l$lib');
-          run(abi.match(Cpp | ObjectiveCpp) ? "g++" : "cc", args);
+          run(lang.match(Cpp | ObjectiveCpp) ? "g++" : "cc", args);
         }
       case [_, _, LinkLibrary(_)]: throw "invalid LinkLibrary command";
       case [File(path), _, EnsureDirectory]:

--- a/src/ammer/core/BuildProgram.hx
+++ b/src/ammer/core/BuildProgram.hx
@@ -87,6 +87,9 @@ class BuildProgram {
       case [File(dst), File(src), CompileObject(lang, opt)]:
         if (useMSVC) {
           var args = [];
+          for (d in opt.defines) {
+            args.push('/D$d');
+          }
           for (path in opt.includePaths) {
             args.push("/I");
             args.push(path);
@@ -97,6 +100,10 @@ class BuildProgram {
           var args = ["-fPIC", "-o", extensions(dst), "-c", extensions(src)];
           if (lang == Cpp || lang == ObjectiveCpp) {
             args.push("-std=c++11");
+          }
+          for (d in opt.defines) {
+            args.push("-D");
+            args.push(d);
           }
           for (path in opt.includePaths) {
             args.push("-I");

--- a/src/ammer/core/FunctionOptions.hx
+++ b/src/ammer/core/FunctionOptions.hx
@@ -10,6 +10,8 @@ typedef FunctionOptions = {
 
   // L3 return expression; default: config.returnIdent
   ?l3Return:String,
+
+  ?comment:String,
 };
 
 #end

--- a/src/ammer/core/Library.hx
+++ b/src/ammer/core/Library.hx
@@ -18,6 +18,7 @@ class Library {
     return @:privateAccess new Marshal(kind, (switch (kind) {
       case Cpp:      (cast library : ammer.core.plat.Cpp.CppLibrary).marshal;
       case Cs:       (cast library : ammer.core.plat.Cs.CsLibrary).marshal;
+      case Eval:     (cast library : ammer.core.plat.Eval.EvalLibrary).marshal;
       case Hashlink: (cast library : ammer.core.plat.Hashlink.HashlinkLibrary).marshal;
       case Java:     (cast library : ammer.core.plat.Java.JavaLibrary).marshal;
       case Lua:      (cast library : ammer.core.plat.Lua.LuaLibrary).marshal;

--- a/src/ammer/core/Library.hx
+++ b/src/ammer/core/Library.hx
@@ -24,6 +24,8 @@ class Library {
       case Neko:     (cast library : ammer.core.plat.Neko.NekoLibrary).marshal;
       case Nodejs:   (cast library : ammer.core.plat.Nodejs.NodejsLibrary).marshal;
       case Python:   (cast library : ammer.core.plat.Python.PythonLibrary).marshal;
+
+      case None:     (cast library : ammer.core.plat.None.NoneLibrary).marshal;
     }));
   }
 

--- a/src/ammer/core/LibraryConfig.hx
+++ b/src/ammer/core/LibraryConfig.hx
@@ -10,7 +10,7 @@ class LibraryConfig {
   public var linkNames:Array<String> = [];
   public var includePaths:Array<String> = [];
   public var libraryPaths:Array<String> = [];
-  public var abi:LibraryAbi = C;
+  public var language:LibraryLanguage = C;
   public var pos:Position = null;
   public var typeDefPack:Array<String> = null;
   public var typeDefName:String = null;
@@ -23,34 +23,6 @@ class LibraryConfig {
   // these two could be per-function?
   public var argPrefix:String = "_arg";
   public var returnIdent:String = "_return";
-}
-
-@:using(ammer.core.LibraryConfig.LibraryAbiTools)
-enum LibraryAbi {
-  C;
-  Cpp;
-  ObjectiveC;
-  ObjectiveCpp;
-}
-
-class LibraryAbiTools {
-  public static function extension(abi:LibraryAbi):String {
-    return (switch (abi) {
-      case C: "c";
-      case Cpp: "cpp";
-      case ObjectiveC: "m";
-      case ObjectiveCpp: "mm";
-    });
-  }
-
-  public static function extensionHeader(abi:LibraryAbi):String {
-    return (switch (abi) {
-      case C: "h";
-      case Cpp: "hpp";
-      case ObjectiveC: "h";
-      case ObjectiveCpp: "hpp"; // TODO: is this correct?
-    });
-  }
 }
 
 #end

--- a/src/ammer/core/LibraryConfig.hx
+++ b/src/ammer/core/LibraryConfig.hx
@@ -10,6 +10,7 @@ class LibraryConfig {
   public var linkNames:Array<String> = [];
   public var includePaths:Array<String> = [];
   public var libraryPaths:Array<String> = [];
+  public var frameworks:Array<String> = [];
   public var defines:Array<String> = [];
   public var language:LibraryLanguage = C;
   public var pos:Position = null;

--- a/src/ammer/core/LibraryConfig.hx
+++ b/src/ammer/core/LibraryConfig.hx
@@ -10,6 +10,7 @@ class LibraryConfig {
   public var linkNames:Array<String> = [];
   public var includePaths:Array<String> = [];
   public var libraryPaths:Array<String> = [];
+  public var defines:Array<String> = [];
   public var language:LibraryLanguage = C;
   public var pos:Position = null;
   public var typeDefPack:Array<String> = null;

--- a/src/ammer/core/LibraryLanguage.hx
+++ b/src/ammer/core/LibraryLanguage.hx
@@ -1,0 +1,29 @@
+package ammer.core;
+
+@:using(ammer.core.LibraryLanguage.LibraryLanguageTools)
+enum LibraryLanguage {
+  C;
+  Cpp;
+  ObjectiveC;
+  ObjectiveCpp;
+}
+
+class LibraryLanguageTools {
+  public static function extension(lang:LibraryLanguage):String {
+    return (switch (lang) {
+      case C: "c";
+      case Cpp: "cpp";
+      case ObjectiveC: "m";
+      case ObjectiveCpp: "mm";
+    });
+  }
+
+  public static function extensionHeader(lang:LibraryLanguage):String {
+    return (switch (lang) {
+      case C: "h";
+      case Cpp: "hpp";
+      case ObjectiveC: "h";
+      case ObjectiveCpp: "hpp"; // TODO: is this correct?
+    });
+  }
+}

--- a/src/ammer/core/Marshal.hx
+++ b/src/ammer/core/Marshal.hx
@@ -48,6 +48,11 @@ class Marshal {
           name: name,
           type: (cast type : ammer.core.plat.Python.PythonTypeMarshal),
         } : ammer.core.plat.BaseFieldRef<ammer.core.plat.Python.PythonTypeMarshal>);
+
+      case None: cast ({
+          name: name,
+          type: (cast type : ammer.core.plat.None.NoneTypeMarshal),
+        } : ammer.core.plat.BaseFieldRef<ammer.core.plat.None.NoneTypeMarshal>);
     });
   }
 

--- a/src/ammer/core/Marshal.hx
+++ b/src/ammer/core/Marshal.hx
@@ -24,6 +24,10 @@ class Marshal {
           name: name,
           type: (cast type : ammer.core.plat.Cs.CsTypeMarshal),
         } : ammer.core.plat.BaseFieldRef<ammer.core.plat.Cs.CsTypeMarshal>);
+      case Eval: cast ({
+          name: name,
+          type: (cast type : ammer.core.plat.Eval.EvalTypeMarshal),
+        } : ammer.core.plat.BaseFieldRef<ammer.core.plat.Eval.EvalTypeMarshal>);
       case Hashlink: cast ({
           name: name,
           type: (cast type : ammer.core.plat.Hashlink.HashlinkTypeMarshal),

--- a/src/ammer/core/MarshalBytes.hx
+++ b/src/ammer/core/MarshalBytes.hx
@@ -19,6 +19,7 @@ typedef MarshalBytes<TTypeMarshal> = {
 
   alloc:(size:Expr)->Expr,
   zalloc:(size:Expr)->Expr,
+  nullPtr:Expr,
   free:(self:Expr)->Expr,
   copy:(self:Expr, size:Expr)->Expr,
   blit:(source:Expr, sourcepos:Expr, dest:Expr, destpos:Expr, size:Expr)->Expr,

--- a/src/ammer/core/MarshalHaxe.hx
+++ b/src/ammer/core/MarshalHaxe.hx
@@ -6,6 +6,7 @@ import haxe.macro.Expr;
 
 typedef MarshalHaxe<TTypeMarshal> = {
   type:TTypeMarshal,
+  refCt:ComplexType,
   create:(val:Expr)->Expr,
   restore:(handle:Expr)->Expr,
 };

--- a/src/ammer/core/MarshalOpaque.hx
+++ b/src/ammer/core/MarshalOpaque.hx
@@ -6,7 +6,7 @@ import haxe.macro.Expr;
 
 typedef MarshalOpaque<TTypeMarshal> = {
   type:TTypeMarshal,
-  typeDeref:TTypeMarshal,
+  nullPtr:Null<Expr>,
 };
 
 #end

--- a/src/ammer/core/Platform.hx
+++ b/src/ammer/core/Platform.hx
@@ -33,13 +33,15 @@ class Platform {
       case "python":
         kind = PlatformId.Python;
         plat = new ammer.core.plat.Python((cast config : ammer.core.plat.Python.PythonConfig));
+
       case _:
-        throw Context.fatalError("unsupported ammer platform", Context.currentPos());
+        kind = PlatformId.None;
+        plat = new ammer.core.plat.None((cast config : ammer.core.plat.None.NoneConfig));
     };
     return new Platform(kind, plat);
   }
 
-  var kind:PlatformId;
+  public var kind(default, null):PlatformId;
   var plat:Dynamic;
 
   function new(kind:PlatformId, plat:Dynamic) {

--- a/src/ammer/core/Platform.hx
+++ b/src/ammer/core/Platform.hx
@@ -48,16 +48,7 @@ class Platform {
   }
 
   public function createLibrary(config:LibraryConfig):Library {
-    return @:privateAccess new Library(kind, (switch (kind) {
-      case Cpp:      new ammer.core.plat.Cpp.CppLibrary(config);
-      case Cs:       new ammer.core.plat.Cs.CsLibrary(config);
-      case Hashlink: new ammer.core.plat.Hashlink.HashlinkLibrary(config);
-      case Java:     new ammer.core.plat.Java.JavaLibrary(cast config);
-      case Lua:      new ammer.core.plat.Lua.LuaLibrary(config);
-      case Neko:     new ammer.core.plat.Neko.NekoLibrary(config);
-      case Nodejs:   new ammer.core.plat.Nodejs.NodejsLibrary(config);
-      case Python:   new ammer.core.plat.Python.PythonLibrary(config);
-    }));
+    return @:privateAccess new Library(kind, plat.createLibrary(config));
   }
 
   public function addLibrary(library:Library):Void {

--- a/src/ammer/core/Platform.hx
+++ b/src/ammer/core/Platform.hx
@@ -15,6 +15,9 @@ class Platform {
       case "cs":
         kind = PlatformId.Cs;
         plat = new ammer.core.plat.Cs((cast config : ammer.core.plat.Cs.CsConfig));
+      case "eval":
+        kind = PlatformId.Eval;
+        plat = new ammer.core.plat.Eval((cast config : ammer.core.plat.Eval.EvalConfig));
       case "hl":
         kind = PlatformId.Hashlink;
         plat = new ammer.core.plat.Hashlink((cast config : ammer.core.plat.Hashlink.HashlinkConfig));

--- a/src/ammer/core/PlatformId.hx
+++ b/src/ammer/core/PlatformId.hx
@@ -9,4 +9,6 @@ enum abstract PlatformId(String) {
   var Neko = "neko";
   var Nodejs = "nodejs";
   var Python = "python";
+
+  var None = "none";
 }

--- a/src/ammer/core/PlatformId.hx
+++ b/src/ammer/core/PlatformId.hx
@@ -3,6 +3,7 @@ package ammer.core;
 enum abstract PlatformId(String) {
   var Cpp = "cpp";
   var Cs = "cs";
+  var Eval = "eval";
   var Hashlink = "hashlink";
   var Java = "java";
   var Lua = "lua";

--- a/src/ammer/core/plat/Base.hx
+++ b/src/ammer/core/plat/Base.hx
@@ -53,7 +53,7 @@ abstract class Base<
   function baseDynamicLinkProgram(options:{
     ?includePaths:Array<String>,
     ?libraryPaths:Array<String>,
-    ?defines:Array<String>,
+    ?defines:TLibrary->Array<String>,
     ?linkNames:Array<String>,
     ?outputPath:TLibrary->String,
   }):BuildProgram {
@@ -80,6 +80,7 @@ abstract class Base<
         File('${config.buildPath}/${lib.config.name}/lib.$platformId.%OBJ%'),
         File('${config.buildPath}/${lib.config.name}/lib.$platformId.$ext'),
         CompileObject(lib.config.language, {
+          defines: (options.defines != null ? options.defines(lib) : lib.config.defines),
           includePaths: (options.includePaths != null ? options.includePaths : [])
             .concat(lib.config.includePaths),
         })
@@ -88,7 +89,7 @@ abstract class Base<
         File('${config.buildPath}/${lib.config.name}/lib.$platformId.%DLL%'),
         File('${config.buildPath}/${lib.config.name}/lib.$platformId.%OBJ%'),
         LinkLibrary(lib.config.language, {
-          defines: (options.defines != null ? options.defines : []),
+          defines: (options.defines != null ? options.defines(lib) : lib.config.defines),
           libraryPaths: (options.libraryPaths != null ? options.libraryPaths : [])
             .concat(lib.config.libraryPaths),
           libraries: (options.linkNames != null ? options.linkNames : [])

--- a/src/ammer/core/plat/Base.hx
+++ b/src/ammer/core/plat/Base.hx
@@ -88,6 +88,7 @@ abstract class Base<
       var outputPath = options.outputPath != null
         ? options.outputPath(lib)
         : '${config.outputPath}/%LIB%${lib.config.name}.%DLL%';
+      var linkName = outputPath.split("/").pop();
       ops.push(BODependent(
         File(outputPath),
         File('${config.buildPath}/${lib.config.name}/lib.$platformId.%OBJ%'),
@@ -97,6 +98,8 @@ abstract class Base<
             .concat(lib.config.libraryPaths),
           libraries: (options.linkNames != null ? options.linkNames : [])
             .concat(lib.config.linkNames),
+          linkName: linkName,
+          frameworks: lib.config.frameworks,
           staticLibraries: [],
         })
       ));

--- a/src/ammer/core/plat/Base.hx
+++ b/src/ammer/core/plat/Base.hx
@@ -85,8 +85,11 @@ abstract class Base<
             .concat(lib.config.includePaths),
         })
       ));
+      var outputPath = options.outputPath != null
+        ? options.outputPath(lib)
+        : '${config.outputPath}/%LIB%${lib.config.name}.%DLL%';
       ops.push(BODependent(
-        File('${config.buildPath}/${lib.config.name}/lib.$platformId.%DLL%'),
+        File(outputPath),
         File('${config.buildPath}/${lib.config.name}/lib.$platformId.%OBJ%'),
         LinkLibrary(lib.config.language, {
           defines: (options.defines != null ? options.defines(lib) : lib.config.defines),
@@ -96,13 +99,6 @@ abstract class Base<
             .concat(lib.config.linkNames),
           staticLibraries: [],
         })
-      ));
-      ops.push(BODependent(
-        File(options.outputPath != null
-          ? options.outputPath(lib)
-          : '${config.outputPath}/%LIB%${lib.config.name}.%DLL%'),
-        File('${config.buildPath}/${lib.config.name}/lib.$platformId.%DLL%'),
-        Copy
       ));
     }
     return new BuildProgram(ops);

--- a/src/ammer/core/plat/Base.hx
+++ b/src/ammer/core/plat/Base.hx
@@ -46,17 +46,27 @@ abstract class Base<
   }):BuildProgram {
     var ops:Array<BuildOp> = [];
     for (lib in libraries) {
-      var ext = lib.config.abi.extension();
+      var ext = lib.config.language.extension();
       ops.push(BOAlways(File('${config.buildPath}/${lib.config.name}'), EnsureDirectory));
       ops.push(BOAlways(File(config.outputPath), EnsureDirectory));
-      ops.push(BOAlways(
-        File('${config.buildPath}/${lib.config.name}/lib.$platformId.$ext'),
-        WriteContent(lib.lb.done())
-      ));
+
+      // Disabling the following operation is useful for debugging. When
+      // disabled, the generated C source is no longer rewritten when Haxe is
+      // invoked, but the remaining operations (compiling objects and linking
+      // a dynamic library) are still performed. It is thus possible to change
+      // the generated C source, e.g. to insert debugging statements, and see
+      // the effects of those changes when Haxe is invoked again.
+      if (true) {
+        ops.push(BOAlways(
+          File('${config.buildPath}/${lib.config.name}/lib.$platformId.$ext'),
+          WriteContent(lib.lb.done())
+        ));
+      }
+
       ops.push(BODependent(
         File('${config.buildPath}/${lib.config.name}/lib.$platformId.%OBJ%'),
         File('${config.buildPath}/${lib.config.name}/lib.$platformId.$ext'),
-        CompileObject(lib.config.abi, {
+        CompileObject(lib.config.language, {
           includePaths: (options.includePaths != null ? options.includePaths : [])
             .concat(lib.config.includePaths),
         })
@@ -64,7 +74,7 @@ abstract class Base<
       ops.push(BODependent(
         File('${config.buildPath}/${lib.config.name}/lib.$platformId.%DLL%'),
         File('${config.buildPath}/${lib.config.name}/lib.$platformId.%OBJ%'),
-        LinkLibrary(lib.config.abi, {
+        LinkLibrary(lib.config.language, {
           defines: (options.defines != null ? options.defines : []),
           libraryPaths: (options.libraryPaths != null ? options.libraryPaths : [])
             .concat(lib.config.libraryPaths),

--- a/src/ammer/core/plat/Base.hx
+++ b/src/ammer/core/plat/Base.hx
@@ -2,12 +2,22 @@ package ammer.core.plat;
 
 import haxe.macro.Expr;
 
+@:allow(ammer.core.plat)
 abstract class Base<
+  TSelf:Base<
+    TSelf,
+    TConfig,
+    TLibraryConfig,
+    TTypeMarshal,
+    TLibrary,
+    TMarshal
+  >,
   TConfig:BaseConfig,
   TLibraryConfig:LibraryConfig,
   TTypeMarshal:BaseTypeMarshal,
   TLibrary:BaseLibrary<
     TLibrary,
+    TSelf,
     TConfig,
     TLibraryConfig,
     TTypeMarshal,
@@ -15,6 +25,7 @@ abstract class Base<
   >,
   TMarshal:BaseMarshal<
     TMarshal,
+    TSelf,
     TConfig,
     TLibraryConfig,
     TLibrary,
@@ -29,6 +40,8 @@ abstract class Base<
     this.platformId = platformId;
     this.config = config;
   }
+
+  abstract public function createLibrary(libConfig:TLibraryConfig):TLibrary;
 
   public function addLibrary(library:TLibrary):Void {
     @:privateAccess library.finalise(config);

--- a/src/ammer/core/plat/BaseLibrary.hx
+++ b/src/ammer/core/plat/BaseLibrary.hx
@@ -10,9 +10,18 @@ import ammer.core.utils.LineBuf;
 abstract class BaseLibrary<
   TSelf:BaseLibrary<
     TSelf,
+    TPlatform,
     TConfig,
     TLibraryConfig,
     TTypeMarshal,
+    TMarshal
+  >,
+  TPlatform:Base<
+    TPlatform,
+    TConfig,
+    TLibraryConfig,
+    TTypeMarshal,
+    TSelf,
     TMarshal
   >,
   TConfig:BaseConfig,
@@ -20,6 +29,7 @@ abstract class BaseLibrary<
   TTypeMarshal:BaseTypeMarshal,
   TMarshal:BaseMarshal<
     TMarshal,
+    TPlatform,
     TConfig,
     TLibraryConfig,
     TSelf,
@@ -28,6 +38,7 @@ abstract class BaseLibrary<
 > {
   public var marshal:TMarshal;
 
+  var platform:TPlatform;
   var config:TLibraryConfig;
   var tdef:TypeDefinition;
   var tdefs:Array<TypeDefinition> = [];
@@ -35,7 +46,8 @@ abstract class BaseLibrary<
   var functionNames:Map<String, Int> = new Map();
   var finalised = false;
 
-  function new(config:TLibraryConfig, marshal:TMarshal) {
+  function new(platform:TPlatform, config:TLibraryConfig, marshal:TMarshal) {
+    this.platform = platform;
     this.marshal = marshal;
     this.config = config;
     if (config.pos == null) config.pos = Context.currentPos();

--- a/src/ammer/core/plat/BaseLibrary.hx
+++ b/src/ammer/core/plat/BaseLibrary.hx
@@ -117,6 +117,9 @@ abstract class BaseLibrary<
     options:FunctionOptions
   ):Void {
     lb
+      .ifi(options.comment != null)
+        .ail("// comment: " + options.comment)
+      .ifd()
       .lmapi(args, (idx, arg) -> '${arg.l2Type} _l2_arg_${idx};')
       .lmapi(args, (idx, arg) -> arg.l1l2(argsL1[idx], '_l2_arg_$idx'))
       .lmapi(args, (idx, arg) -> '${arg.l3Type} ${config.argPrefix}${idx};')

--- a/src/ammer/core/plat/BaseLibrary.hx
+++ b/src/ammer/core/plat/BaseLibrary.hx
@@ -5,6 +5,7 @@ package ammer.core.plat;
 import haxe.macro.Context;
 import haxe.macro.Expr;
 import ammer.core.utils.LineBuf;
+import ammer.core.utils.TypeUtils;
 
 @:allow(ammer.core.plat)
 abstract class BaseLibrary<
@@ -70,7 +71,7 @@ abstract class BaseLibrary<
     if (finalised) throw "library was already finalised";
     finalised = true;
     for (tdef in tdefs) {
-      Context.defineType(tdef); // TODO: moduleDependency arg
+      TypeUtils.defineType(tdef); // TODO: moduleDependency arg
     }
   }
 

--- a/src/ammer/core/plat/BaseMarshal.hx
+++ b/src/ammer/core/plat/BaseMarshal.hx
@@ -750,15 +750,6 @@ ${library.config.memcpyFunction}(_return, _arg0, sizeof($name));'
   abstract function haxePtrInternal(haxeType:haxe.macro.Type):TTypeMarshal;
   */
 
-  /*
-  public function haxePtr(haxeType:ComplexType):TTypeMarshal {
-    var cacheKey = Mangle.complexType(haxeType);
-    if (cacheHaxe.exists(cacheKey))
-      return cacheHaxe[cacheKey];
-    return cacheHaxe[cacheKey] = haxePtrInternal(haxeType);
-  }
-*/
-
   public function haxePtr(haxeType:ComplexType):MarshalHaxe<TTypeMarshal> {
     var cacheKey = Mangle.complexType(haxeType);
     if (cacheHaxe.exists(cacheKey))
@@ -838,6 +829,7 @@ ${library.config.memcpyFunction}(_return, _arg0, sizeof($name));'
       tdef: tdefRef,
       marshal: {
         type: haxePtrInternalType(haxeType),
+        refCt: ct,
         create: (val) -> macro @:privateAccess $p{tp.pack.concat([tp.name])}.create($val),
         restore: (handle) -> macro @:privateAccess $p{tp.pack.concat([tp.name])}.restore($handle),
       },

--- a/src/ammer/core/plat/BaseMarshal.hx
+++ b/src/ammer/core/plat/BaseMarshal.hx
@@ -9,10 +9,11 @@ using Lambda;
 
 // TODO: add std.* prefix to `haxeType`s
 abstract class BaseMarshal<
-  TSelf:BaseMarshal<TSelf, TConfig, TLibraryConfig, TLibrary, TTypeMarshal>,
+  TSelf:BaseMarshal<TSelf, TPlatform, TConfig, TLibraryConfig, TLibrary, TTypeMarshal>,
+  TPlatform:Base<TPlatform, TConfig, TLibraryConfig, TTypeMarshal, TLibrary, TSelf>,
   TConfig:BaseConfig,
   TLibraryConfig:LibraryConfig,
-  TLibrary:BaseLibrary<TLibrary, TConfig, TLibraryConfig, TTypeMarshal, TSelf>,
+  TLibrary:BaseLibrary<TLibrary, TPlatform, TConfig, TLibraryConfig, TTypeMarshal, TSelf>,
   TTypeMarshal:BaseTypeMarshal
 > {
   static final MARSHAL_NOOP1 = (_:String) -> "";

--- a/src/ammer/core/plat/BaseMarshal.hx
+++ b/src/ammer/core/plat/BaseMarshal.hx
@@ -762,7 +762,7 @@ ${library.config.memcpyFunction}(_return, _arg0, sizeof($name));'
   } {
     var mangled = 'h${Mangle.complexType(haxeType)}_';
 
-    var tdefRef = library.typeDefCreate();
+    var tdefRef = library.typeDefCreate(false);
     tdefRef.name += '_HaxeRef_$mangled';
     var tp = {
       name: tdefRef.name,

--- a/src/ammer/core/plat/BaseMarshal.hx
+++ b/src/ammer/core/plat/BaseMarshal.hx
@@ -241,6 +241,11 @@ abstract class BaseMarshal<
       [int32()],
       '_return = (uint8_t*)${library.config.callocFunction}(_arg0, 1);'
     );
+    var nullPtr = library.addFunction(
+      type,
+      [],
+      '_return = (uint8_t*)0;'
+    );
     var free = library.addFunction(
       void(),
       [type],
@@ -265,6 +270,7 @@ ${library.config.memcpyFunction}(_return, _arg0, _arg1);'
 
       alloc: alloc,
       zalloc: (size) -> macro $zalloc($size),
+      nullPtr: macro $e{nullPtr}(),
       free: (self) -> macro $free($self),
       copy: (self, size) -> macro $copy($self, $size),
       blit: blit,

--- a/src/ammer/core/plat/BaseMarshal.hx
+++ b/src/ammer/core/plat/BaseMarshal.hx
@@ -193,6 +193,19 @@ abstract class BaseMarshal<
     l2l1: MARSHAL_CONVERT_DIRECT,
     arrayBits: 3,
   };
+  static function baseFloat64As32():BaseTypeMarshal return {
+    haxeType: (macro : Float),
+    l1Type: "double",
+    l2Type: "double",
+    l3Type: "float",
+    mangled: "f32",
+    l1l2: MARSHAL_CONVERT_DIRECT,
+    l2l3: MARSHAL_CONVERT_DIRECT, // cast?
+    l3l2: MARSHAL_CONVERT_DIRECT, // cast?
+    l2l1: MARSHAL_CONVERT_DIRECT,
+    arrayBits: 2,
+  };
+  // TODO: flag to enable lossy double/single conversions
   abstract public function float32():TTypeMarshal;
   abstract public function float64():TTypeMarshal;
 

--- a/src/ammer/core/plat/Cpp.hx
+++ b/src/ammer/core/plat/Cpp.hx
@@ -2,12 +2,6 @@ package ammer.core.plat;
 
 #if macro
 
-import haxe.macro.Context;
-import haxe.macro.Expr;
-import ammer.core.utils.*;
-
-using Lambda;
-
 @:structInit
 class CppConfig extends BaseConfig {
   public var staticLink:Bool = true;

--- a/src/ammer/core/plat/Cpp.hx
+++ b/src/ammer/core/plat/Cpp.hx
@@ -209,6 +209,8 @@ void _ammer_ref_${config.name}_delete(_ammer_haxe_ref* ref) {
           .lmap(config.libraryPaths, path -> '<libpath name="$path"/>')
           .lmap(config.linkNames, name -> '<lib name="-l$name" unless="windows" />')
           .lmap(config.linkNames, name -> '<lib name="$name" if="windows" />')
+          // TODO: allow only on Mac
+          .lmap(config.frameworks, name -> '<flag value="-framework" /><flag value="$name" />')
         .d()
         .ail("</target>")
       //.ifd()

--- a/src/ammer/core/plat/Cpp.hx
+++ b/src/ammer/core/plat/Cpp.hx
@@ -32,8 +32,8 @@ class Cpp extends Base<
   public function finalise():BuildProgram {
     var ops:Array<BuildOp> = [];
     for (lib in libraries) {
-      var ext = lib.config.abi.extension();
-      var exth = lib.config.abi.extensionHeader();
+      var ext = lib.config.language.extension();
+      var exth = lib.config.language.extensionHeader();
       ops.push(BOAlways(File('${config.buildPath}/${lib.config.name}'), EnsureDirectory));
       ops.push(BOAlways(File(config.outputPath), EnsureDirectory));
       ops.push(BOAlways(
@@ -81,6 +81,9 @@ class CppLibrary extends BaseLibrary<
 
   public function new(config:CppLibraryConfig) {
     super(config, new CppMarshal(this));
+
+    var exth = config.language.extensionHeader();
+    var ext = config.language.extension();
 
     var native = typeDefCreate();
     native.name = '${config.typeDefName}_NativeHaxeRef';
@@ -141,8 +144,8 @@ void _ammer_ref_setcount(_ammer_haxe_ref* ref, int32_t rc) {
   }
 
   override function finalise(platConfig:CppConfig):Void {
-    var ext = config.abi.extension();
-    var exth = config.abi.extensionHeader();
+    var ext = config.language.extension();
+    var exth = config.language.extensionHeader();
     var absLibPath = sys.FileSystem.absolutePath('${platConfig.buildPath}/${config.name}');
     var headerPath = '$absLibPath/lib.cpp_static.$exth';
     var codePath = '$absLibPath/lib.cpp_static.$ext';

--- a/src/ammer/core/plat/Cpp.hx
+++ b/src/ammer/core/plat/Cpp.hx
@@ -450,7 +450,7 @@ class CppMarshal extends BaseMarshal<
     };
   }
 
-  function opaqueInternal(name:String):MarshalOpaque<CppTypeMarshal> {
+  function opaqueInternal(name:String):CppTypeMarshal {
     var native = library.typeDefCreate(false);
     native.name = '${library.config.typeDefName}_Native_${Mangle.identifier(name)}';
     native.isExtern = true;
@@ -469,14 +469,24 @@ class CppMarshal extends BaseMarshal<
       pack: ["cpp"],
       name: "Pointer", // Star?
     });
-    return {
-      type: baseExtend(BaseMarshal.baseOpaquePtrInternal(name), {
-        haxeType: haxeType,
-      }),
-      typeDeref: baseExtend(BaseMarshal.baseOpaqueDirectInternal(name), {
-        haxeType: haxeType,
-      }),
-    };
+    return baseExtend(BaseMarshal.baseOpaqueInternal(name), {
+      haxeType: haxeType,
+    });
+  }
+
+  function structPtrDerefInternal(name:String):CppTypeMarshal {
+    var haxeType:ComplexType = TPath({
+      params: [TPType(TPath({
+        pack: library.config.typeDefPack,
+        // TODO: bit hacky, this works because opaqueInternal was called before
+        name: '${library.config.typeDefName}_Native_${Mangle.identifier('$name*')}',
+      }))],
+      pack: ["cpp"],
+      name: "Pointer", // Star?
+    });
+    return baseExtend(BaseMarshal.baseStructPtrDerefInternal(name), {
+      haxeType: haxeType,
+    });
   }
 
   function arrayPtrInternalType(element:CppTypeMarshal):CppTypeMarshal {

--- a/src/ammer/core/plat/Cpp.hx
+++ b/src/ammer/core/plat/Cpp.hx
@@ -18,6 +18,7 @@ typedef CppLibraryConfig = LibraryConfig;
 typedef CppTypeMarshal = BaseTypeMarshal;
 
 class Cpp extends Base<
+  Cpp,
   CppConfig,
   CppLibraryConfig,
   CppTypeMarshal,
@@ -27,6 +28,10 @@ class Cpp extends Base<
   public function new(config:CppConfig) {
     super("cpp-static", config);
     if (!config.staticLink) throw "todo";
+  }
+
+  public function createLibrary(libConfig:CppLibraryConfig):CppLibrary {
+    return new CppLibrary(this, libConfig);
   }
 
   public function finalise():BuildProgram {
@@ -52,6 +57,7 @@ class Cpp extends Base<
 @:allow(ammer.core.plat)
 class CppLibrary extends BaseLibrary<
   CppLibrary,
+  Cpp,
   CppConfig,
   CppLibraryConfig,
   CppTypeMarshal,
@@ -79,8 +85,8 @@ class CppLibrary extends BaseLibrary<
     });
   }
 
-  public function new(config:CppLibraryConfig) {
-    super(config, new CppMarshal(this));
+  public function new(platform:Cpp, config:CppLibraryConfig) {
+    super(platform, config, new CppMarshal(this));
 
     var exth = config.language.extensionHeader();
     var ext = config.language.extension();
@@ -325,6 +331,7 @@ void _ammer_ref_setcount(_ammer_haxe_ref* ref, int32_t rc) {
 @:allow(ammer.core.plat)
 class CppMarshal extends BaseMarshal<
   CppMarshal,
+  Cpp,
   CppConfig,
   CppLibraryConfig,
   CppLibrary,

--- a/src/ammer/core/plat/Cs.hx
+++ b/src/ammer/core/plat/Cs.hx
@@ -23,6 +23,7 @@ typedef CsTypeMarshal = {
 };
 
 class Cs extends Base<
+  Cs,
   CsConfig,
   CsLibraryConfig,
   CsTypeMarshal,
@@ -31,6 +32,10 @@ class Cs extends Base<
 > {
   public function new(config:CsConfig) {
     super("cs", config);
+  }
+
+  public function createLibrary(libConfig:CsLibraryConfig):CsLibrary {
+    return new CsLibrary(this, libConfig);
   }
 
   public function finalise():BuildProgram {
@@ -43,6 +48,7 @@ class Cs extends Base<
 @:allow(ammer.core.plat)
 class CsLibrary extends BaseLibrary<
   CsLibrary,
+  Cs,
   CsConfig,
   CsLibraryConfig,
   CsTypeMarshal,
@@ -53,8 +59,8 @@ class CsLibrary extends BaseLibrary<
 
   var lbImport = new LineBuf();
 
-  public function new(config:CsLibraryConfig) {
-    super(config, new CsMarshal(this));
+  public function new(platform:Cs, config:CsLibraryConfig) {
+    super(platform, config, new CsMarshal(this));
     tdef.meta.push({
       pos: config.pos,
       name: ":nativeGen",
@@ -263,6 +269,7 @@ LIB_EXPORT int _ammer_init(void* delegates[${delegateCtr}]) {
 @:allow(ammer.core.plat)
 class CsMarshal extends BaseMarshal<
   CsMarshal,
+  Cs,
   CsConfig,
   CsLibraryConfig,
   CsLibrary,

--- a/src/ammer/core/plat/Cs.hx
+++ b/src/ammer/core/plat/Cs.hx
@@ -406,20 +406,21 @@ class CsMarshal extends BaseMarshal<
     };
   }
 
-  function opaqueInternal(name:String):MarshalOpaque<CsTypeMarshal> return {
-    type: baseExtend(BaseMarshal.baseOpaquePtrInternal(name), {
+  function opaqueInternal(name:String):CsTypeMarshal return baseExtend(BaseMarshal.baseOpaqueInternal(name), {
+    primitive: false,
+    csType: "System.IntPtr",
+  }, {
+    haxeType: (macro : cs.system.IntPtr),
+  });
+
+  function structPtrDerefInternal(name:String):CsTypeMarshal {
+    return baseExtend(BaseMarshal.baseStructPtrDerefInternal(name), {
       primitive: false,
       csType: "System.IntPtr",
     }, {
       haxeType: (macro : cs.system.IntPtr),
-    }),
-    typeDeref: baseExtend(BaseMarshal.baseOpaqueDirectInternal(name), {
-      primitive: false,
-      csType: "System.IntPtr",
-    }, {
-      haxeType: (macro : cs.system.IntPtr),
-    }),
-  };
+    });
+  }
 
   function arrayPtrInternalType(element:CsTypeMarshal):CsTypeMarshal {
     var elType = element.arrayType != null ? element.arrayType : element.haxeType;

--- a/src/ammer/core/plat/Cs.hx
+++ b/src/ammer/core/plat/Cs.hx
@@ -2,13 +2,6 @@ package ammer.core.plat;
 
 #if macro
 
-import haxe.macro.Context;
-import haxe.macro.Expr;
-import ammer.core.utils.*;
-
-using Lambda;
-using StringTools;
-
 typedef CsConfig = BaseConfig;
 
 typedef CsLibraryConfig = LibraryConfig;

--- a/src/ammer/core/plat/Cs.hx
+++ b/src/ammer/core/plat/Cs.hx
@@ -635,6 +635,7 @@ return old_val;';
       }).fields
     );
     library.haxeRefTdefs[ret.mangled] = ret.tdef;
+    TypeUtils.defineType(ret.tdef);
     return ret.marshal;
   }
 

--- a/src/ammer/core/plat/Eval.hx
+++ b/src/ammer/core/plat/Eval.hx
@@ -1,0 +1,674 @@
+package ammer.core.plat;
+
+#if macro
+
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import ammer.core.utils.*;
+
+using Lambda;
+
+@:structInit
+class EvalConfig extends BaseConfig {
+  public var haxeRepoPath:String;
+}
+
+typedef EvalLibraryConfig = LibraryConfig;
+
+typedef EvalTypeMarshalExt = {
+  mlType:String,
+  evalL1:(eval:String)->String,
+  l1Eval:(l1:String)->String,
+};
+typedef EvalTypeMarshal = {
+  >BaseTypeMarshal,
+  >EvalTypeMarshalExt,
+};
+
+class Eval extends Base<
+  Eval,
+  EvalConfig,
+  EvalLibraryConfig,
+  EvalTypeMarshal,
+  EvalLibrary,
+  EvalMarshal
+> {
+  public function new(config:EvalConfig) {
+    super("eval", config);
+  }
+
+  public function createLibrary(libConfig:EvalLibraryConfig):EvalLibrary {
+    return new EvalLibrary(this, libConfig);
+  }
+
+  public function finalise():BuildProgram {
+    var ops:Array<BuildOp> = [];
+    for (lib in libraries) {
+      // TODO: avoid clashes in the Haxe plugins directory somehow
+      ops.push(BOAlways(File('${config.haxeRepoPath}/plugins/ammer_core_${lib.config.name}/c'), EnsureDirectory));
+      ops.push(BOAlways(File('${config.haxeRepoPath}/plugins/ammer_core_${lib.config.name}/ml'), EnsureDirectory));
+      ops.push(BOAlways(
+        File('${config.haxeRepoPath}/plugins/ammer_core_${lib.config.name}/dune'),
+        WriteContent('(data_only_dirs cmxs hx)
+(include_subdirs unqualified)
+(library
+  (name ammer_core_${lib.config.name})
+  (libraries haxe)
+  (c_names stubs)
+)')
+      ));
+      ops.push(BOAlways(
+        File('${config.haxeRepoPath}/plugins/ammer_core_${lib.config.name}/c/stubs.c'),
+        WriteContent(lib.lb.done())
+      ));
+      ops.push(BOAlways(
+        File('${config.haxeRepoPath}/plugins/ammer_core_${lib.config.name}/ml/plugin.ml'),
+        WriteContent(lib.lbml.done())
+      ));
+      ops.push(BOCwd(
+        config.haxeRepoPath,
+        [
+          // TODO: MSVC support
+          BOAlways(File(""), Command("make", ["plugin", 'PLUGIN=ammer_core_${lib.config.name}'])),
+        ]
+      ));
+      ops.push(BODependent(
+        // TODO: bytecode
+        File('${config.buildPath}/${lib.config.name}.${Sys.systemName()}.cmxs'),
+        File('${config.haxeRepoPath}/plugins/ammer_core_${lib.config.name}/cmxs/${Sys.systemName()}/plugin.cmxs'),
+        Copy
+      ));
+    }
+    return new BuildProgram(ops);
+  }
+}
+
+@:allow(ammer.core.plat)
+class EvalLibrary extends BaseLibrary<
+  EvalLibrary,
+  Eval,
+  EvalConfig,
+  EvalLibraryConfig,
+  EvalTypeMarshal,
+  EvalMarshal
+> {
+  var lbInit = new LineBuf();
+  var lbml = new LineBuf();
+
+  public function new(platform:Eval, config:EvalLibraryConfig) {
+    super(platform, config, new EvalMarshal(this));
+
+    lb.ail('#define CAML_NAME_SPACE
+#include <caml/alloc.h>
+#include <caml/callback.h>
+#include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
+
+CAMLprim value _ammer_eval_tohaxecopy(value data, value size) {
+  CAMLparam2(data, size);
+  uint8_t* data_w = (uint8_t*)Int64_val(Field(data, 0));
+  uint32_t size_w = Int32_val(Field(size, 0));
+  CAMLlocal1(ret);
+  ret = caml_alloc_string(size_w);
+  ${config.memcpyFunction}(&Byte_u(ret, 0), data_w, size_w);
+  CAMLreturn(ret);
+}
+CAMLprim value _ammer_eval_fromhaxecopy(value data, value size) {
+  CAMLparam2(data, size);
+  uint8_t* data_w = &Byte_u(data, 0);
+  uint32_t size_w = Int32_val(Field(size, 0));
+  uint8_t* ret_w = (uint8_t*)${config.mallocFunction}(size_w);
+  ${config.memcpyFunction}(ret_w, data_w, size_w);
+  CAMLlocal2(ret, tmp);
+  ret = caml_alloc(1, 15);
+  tmp = caml_copy_int64((int64_t)ret_w);
+  Store_field(ret, 0, tmp);
+  CAMLreturn(ret);
+}
+
+typedef struct { value data; int32_t refcount; } _ammer_haxe_ref;
+CAMLprim value _ammer_ref_create(value obj) {
+  CAMLparam1(obj);
+  _ammer_haxe_ref* ref = (_ammer_haxe_ref*)${config.mallocFunction}(sizeof(_ammer_haxe_ref));
+  ref->data = obj;
+  caml_register_global_root(&ref->data);
+  ref->refcount = 0;
+  CAMLlocal2(ret, tmp);
+  ret = caml_alloc(1, 15);
+  tmp = caml_copy_int64((int64_t)ref);
+  Store_field(ret, 0, tmp);
+  CAMLreturn(ret);
+}
+CAMLprim value _ammer_ref_delete(value vref) {
+  CAMLparam1(vref);
+  _ammer_haxe_ref* ref = (_ammer_haxe_ref*)Int64_val(Field(vref, 0));
+  caml_remove_global_root(&ref->data);
+  ref->data = Val_unit;
+  ${config.freeFunction}(ref);
+  CAMLreturn(Val_unit);
+}
+CAMLprim value _ammer_ref_getcount(value vref) {
+  CAMLparam1(vref);
+  _ammer_haxe_ref* ref = (_ammer_haxe_ref*)Int64_val(Field(vref, 0));
+  CAMLlocal2(ret, tmp);
+  ret = caml_alloc(1, 0);
+  tmp = caml_copy_int32(ref->refcount);
+  Store_field(ret, 0, tmp);
+  CAMLreturn(ret);
+}
+CAMLprim value _ammer_ref_setcount(value vref, value wrc) {
+  CAMLparam2(vref, wrc);
+  _ammer_haxe_ref* ref = (_ammer_haxe_ref*)Int64_val(Field(vref, 0));
+  ref->refcount = Int32_val(Field(wrc, 0));
+  CAMLreturn(Val_unit);
+}
+CAMLprim value _ammer_ref_getvalue(value vref) {
+  CAMLparam1(vref);
+  _ammer_haxe_ref* ref = (_ammer_haxe_ref*)Int64_val(Field(vref, 0));
+  CAMLreturn(ref->data);
+}
+');
+
+    lbml.ail('
+open EvalContext
+open EvalDecode
+open EvalEncode
+open EvalExceptions
+open EvalHash
+open EvalIntegers
+open EvalStdLib
+open EvalValue
+
+(* see https://github.com/HaxeFoundation/haxe/pull/10800 *)
+let decode_haxe_i64_fix v =
+	match v with
+	| VInstance vi when is v key_haxe__Int64____Int64 ->
+		let high = decode_i32 (vi.ifields.(get_instance_field_index_raise vi.iproto key_high))
+		and low = decode_i32 (vi.ifields.(get_instance_field_index_raise vi.iproto key_low)) in
+		let high64 = Int64.shift_left (Signed.Int32.to_int64 high) 32
+		and low64 = Int64.logand (Signed.Int32.to_int64 low) 0xffffffffL in
+		Int64.logor high64 low64
+	| _ ->
+		unexpected_value v "haxe.Int64"
+
+external _ammer_eval_tohaxecopy : value -> value -> bytes = "_ammer_eval_tohaxecopy"
+external _ammer_eval_fromhaxecopy : bytes -> value -> value = "_ammer_eval_fromhaxecopy"
+
+external _ammer_ref_create : value -> value = "_ammer_ref_create"
+external _ammer_ref_delete : value -> value = "_ammer_ref_delete"
+external _ammer_ref_getcount : value -> value = "_ammer_ref_getcount"
+external _ammer_ref_setcount : value -> value -> value = "_ammer_ref_setcount"
+external _ammer_ref_getvalue : value -> value = "_ammer_ref_getvalue"
+');
+
+    tdef.fields.push({
+      pos: config.pos,
+      name: "_ammer_native",
+      kind: FVar(
+        (macro : Any),
+        macro eval.vm.Context.loadPlugin($v{platform.config.buildPath} + "/" + $v{config.name} + "." + Sys.systemName() + ".cmo")
+      ),
+      access: [APrivate, AStatic],
+    });
+  }
+
+  override function finalise(platConfig:EvalConfig):Void {
+    lbml
+      .ail(";; EvalStdLib.StdContext.register [")
+      .ail('"_ammer_eval_tohaxecopy", vstatic_function (function | [v1;v2] -> encode_bytes (_ammer_eval_tohaxecopy v1 v2) | _ -> assert false);')
+      .ail('"_ammer_eval_fromhaxecopy", vstatic_function (function | [v1;v2] -> _ammer_eval_fromhaxecopy (decode_bytes v1) v2 | _ -> assert false);')
+      .ail('"_ammer_ref_create", vstatic_function (function | [v1] -> _ammer_ref_create v1 | _ -> assert false);')
+      .ail('"_ammer_ref_delete", vstatic_function (function | [v1] -> _ammer_ref_delete v1 | _ -> assert false);')
+      .ail('"_ammer_ref_getcount", vstatic_function (function | [v1] -> _ammer_ref_getcount v1 | _ -> assert false);')
+      .ail('"_ammer_ref_setcount", vstatic_function (function | [v1;v2] -> _ammer_ref_setcount v1 v2 | _ -> assert false);')
+      .ail('"_ammer_ref_getvalue", vstatic_function (function | [v1] -> _ammer_ref_getvalue v1 | _ -> assert false);')
+      .addBuf(lbInit)
+      .ail("];");
+    super.finalise(platConfig);
+  }
+
+  public function addNamedFunction(
+    name:String,
+    ret:EvalTypeMarshal,
+    args:Array<EvalTypeMarshal>,
+    code:String,
+    options:FunctionOptions
+  ):Expr {
+    if (args.length > 5) {
+      lb.ail('CAMLprim value bc_${name}(value *argv, int argn) {')
+        .i()
+          .ai('return nat_${name}(')
+          .mapi(args, (idx, arg) -> 'argv[$idx]', ", ")
+          .al(');')
+        .d()
+        .ail("}");
+    }
+    lb.ai('CAMLprim value nat_${name}(')
+      .mapi(args, (idx, arg) -> 'value _l1_arg_$idx', ", ")
+      .a(args.length == 0 ? "void" : "")
+      .al(') {')
+      .i();
+    var pi = 0;
+    while (pi < args.length) {
+      var sub = [ for (i in pi...Std.int(Math.min(args.length, pi + 5))) i ];
+      lb.ail('CAML${pi == 0 ? "" : "x"}param${sub.length}(${sub.map(s -> '_l1_arg_$s').join(", ")});');
+      pi += 5;
+    }
+    if (args.length == 0)
+      lb.ail("CAMLparam0();");
+    lb.ail("CAMLlocal1(_eval_tmp);");
+    baseAddNamedFunction(
+      args,
+      args.mapi((idx, arg) -> '_l1_arg_$idx'),
+      ret,
+      "_l1_return",
+      code,
+      lb,
+      options
+    );
+    lb
+        .ifi(ret.mangled != "v")
+          .ail('CAMLreturn(_l1_return);')
+        .ife()
+          .ail("CAMLreturn(Val_unit);")
+        .ifd()
+      .d()
+      .ail("}");
+    lbml.ai('external $name : ')
+      .a(args.length == 0 ? "unit" : "")
+      .map(args, arg -> arg.mlType, " -> ")
+      .a(" -> ")
+      .a(ret.mlType)
+      .a(" =")
+      .ifi(args.length > 5)
+        .a(' "bc_$name"')
+      .ifd()
+      .al(' "nat_$name"');
+    var evalCall = new LineBuf()
+      .a('$name ')
+      .mapi(args, (idx, arg) -> arg.evalL1('arg$idx'), " ")
+      .a(args.length == 0 ? "()" : "")
+      .done();
+    lbInit.ail('"${name}", vstatic_function (function')
+      .ai('| [')
+      .mapi(args, (idx, arg) -> 'arg$idx', "; ")
+      .a('] -> ')
+      .al(ret.l1Eval(evalCall))
+      .al('| _ -> vbool true);');
+    var funcType = TFunction(args.map(arg -> arg.haxeType), ret.haxeType);
+    // TODO: position?
+    return macro ((untyped $e{fieldExpr("_ammer_native")}.$name) : $funcType);
+  }
+
+  var closureScope = 0;
+  public function closureCall(
+    fn:String,
+    clType:MarshalClosure<EvalTypeMarshal>,
+    outputExpr:String,
+    args:Array<String>
+  ):String {
+    // TODO: ref/unref args?
+    // CAMLlocal within scopes (`do { ... } while (0);` as in other platforms)
+    // might be problematic, use a counter instead
+    var scope = '_cl${closureScope++}';
+    return new LineBuf()
+      .ail('${clType.type.l2Type} ${scope}_l2_fn;')
+      .ail(clType.type.l3l2(fn, '${scope}_l2_fn'))
+      .lmapi(args, (idx, arg) -> '${clType.args[idx].l2Type} ${scope}_l2_arg_${idx};')
+      .lmapi(args, (idx, arg) -> clType.args[idx].l3l2(arg, '${scope}_l2_arg_$idx'))
+      .ail('CAMLlocal1(${scope}_l1_fn_ref);')
+      .ail(clType.type.l2l1('${scope}_l2_fn', '${scope}_l1_fn_ref'))
+      .ail('CAMLlocal1(${scope}_l1_fn);')
+      .ail('${scope}_l1_fn = ((_ammer_haxe_ref*)Int64_val(Field(${scope}_l1_fn_ref, 0)))->data;')
+
+      // TODO: what about VFieldClosure ?
+      .ail('${scope}_l1_fn = Field(${scope}_l1_fn, 0);') // VFunction of vfunc * bool
+      .lmapi(args, (idx, arg) -> 'CAMLlocal1(${scope}_l1_arg_${idx});')
+      .lmapi(args, (idx, arg) -> clType.args[idx].l2l1('${scope}_l2_arg_$idx', '${scope}_l1_arg_$idx'))
+
+      // args are a linked list (`value list`)
+      .ail('CAMLlocal1(${scope}_l1_arg_${args.length}_cell);
+${scope}_l1_arg_${args.length}_cell = Val_int(0);')
+      .lmapi(args, (idx, arg) -> 'CAMLlocal1(${scope}_l1_arg_${idx}_cell);
+${scope}_l1_arg_${idx}_cell = caml_alloc(2, 0);
+Store_field(${scope}_l1_arg_${idx}_cell, 0, ${scope}_l1_arg_${idx});')
+      .lmapi(args, (idx, arg) -> 'Store_field(${scope}_l1_arg_${idx}_cell, 1, ${scope}_l1_arg_${idx + 1}_cell);')
+
+      .ifi(clType.ret.mangled != "v")
+        .ail('${clType.ret.l1Type} ${scope}_l1_output;')
+        .ail('${scope}_l1_output = caml_callback(${scope}_l1_fn, ${scope}_l1_arg_0_cell);')
+        .ail('${clType.ret.l2Type} ${scope}_l2_output;')
+        .ail(clType.ret.l1l2('${scope}_l1_output', '${scope}_l2_output'))
+        .ail(clType.ret.l2l3('${scope}_l2_output', outputExpr))
+      .ife()
+        .ail('caml_callback(${scope}_l1_fn, ${scope}_l1_arg_0_cell);')
+      .ifd()
+      .done();
+  }
+
+  public function addCallback(
+    ret:EvalTypeMarshal,
+    args:Array<EvalTypeMarshal>,
+    code:String
+  ):String {
+    var name = mangleFunction(ret, args, code, "cb");
+    lb
+      .ai('static ${ret.l3Type} ${name}(')
+      .mapi(args, (idx, arg) -> '${arg.l3Type} ${config.argPrefix}${idx}', ", ")
+      .a(args.length == 0 ? "void" : "")
+      .al(") {")
+      .i()
+        .ail("CAMLparam0();")
+        .ail("CAMLlocal1(_eval_tmp);")
+        .ifi(ret.mangled != "v")
+          .ail('${ret.l3Type} ${config.returnIdent};')
+          .ail(code)
+          .ail('CAMLreturn(${config.returnIdent});')
+        .ife()
+          .ail(code)
+          .ail("CAMLreturn0;")
+        .ifd()
+      .d()
+      .al("}");
+    return name;
+  }
+}
+
+@:allow(ammer.core.plat)
+class EvalMarshal extends BaseMarshal<
+  EvalMarshal,
+  Eval,
+  EvalConfig,
+  EvalLibraryConfig,
+  EvalLibrary,
+  EvalTypeMarshal
+> {
+  static function baseExtend(
+    base:BaseTypeMarshal,
+    ext:EvalTypeMarshalExt,
+    ?over:BaseTypeMarshal.BaseTypeMarshalOpt
+  ):EvalTypeMarshal {
+    return {
+      haxeType:  over != null && over.haxeType  != null ? over.haxeType  : base.haxeType,
+      // L1 type is always "value", an OCaml tagged pointer
+      l1Type:   "value",
+      l2Type:    over != null && over.l2Type    != null ? over.l2Type    : base.l2Type,
+      l3Type:    over != null && over.l3Type    != null ? over.l3Type    : base.l3Type,
+      mangled:   over != null && over.mangled   != null ? over.mangled   : base.mangled,
+      l1l2:      over != null && over.l1l2      != null ? over.l1l2      : base.l1l2,
+      l2l3:      over != null && over.l2l3      != null ? over.l2l3      : base.l2l3,
+      l3l2:      over != null && over.l3l2      != null ? over.l3l2      : base.l3l2,
+      l2l1:      over != null && over.l2l1      != null ? over.l2l1      : base.l2l1,
+      arrayBits: over != null && over.arrayBits != null ? over.arrayBits : base.arrayBits,
+      arrayType: over != null && over.arrayType != null ? over.arrayType : base.arrayType,
+      mlType:    ext.mlType,
+      evalL1:    ext.evalL1,
+      l1Eval:    ext.l1Eval,
+    };
+  }
+
+  static final MARSHAL_DIRECT = (v:String) -> v;
+
+  static final MARSHAL_VOID = baseExtend(BaseMarshal.baseVoid(), {
+    mlType: "value",
+    evalL1: MARSHAL_DIRECT,
+    l1Eval: MARSHAL_DIRECT,
+  }, {
+    l1l2: BaseMarshal.MARSHAL_NOOP2,
+    l2l1: (l2, l1) -> '$l1 = Val_unit;',
+  });
+  public function void():EvalTypeMarshal return MARSHAL_VOID;
+
+  static final MARSHAL_BOOL = baseExtend(BaseMarshal.baseBool(), {
+    mlType: "value",
+    evalL1: MARSHAL_DIRECT,
+    l1Eval: MARSHAL_DIRECT,
+  }, {
+    l1l2: (l1, l2) -> '$l2 = (Int_val($l1) == 1);',
+    l2l1: (l2, l1) -> '$l1 = Val_int($l2 ? 1 : 2);',
+  });
+  public function bool():EvalTypeMarshal return MARSHAL_BOOL;
+
+  static final MARSHAL_UINT8 = baseExtend(BaseMarshal.baseUint8(), {
+    mlType: "value",
+    evalL1: MARSHAL_DIRECT,
+    l1Eval: MARSHAL_DIRECT,
+  }, {
+    l1l2: (l1, l2) -> '$l2 = Int32_val(Field($l1, 0));',
+    l2l1: (l2, l1) -> '$l1 = caml_alloc(1, 0);
+_eval_tmp = caml_copy_int32($l2);
+Store_field($l1, 0, _eval_tmp);',
+  });
+  static final MARSHAL_INT8 = baseExtend(BaseMarshal.baseInt8(), {
+    mlType: "value",
+    evalL1: MARSHAL_DIRECT,
+    l1Eval: MARSHAL_DIRECT,
+  }, {
+    l1l2: (l1, l2) -> '$l2 = Int32_val(Field($l1, 0));',
+    l2l1: (l2, l1) -> '$l1 = caml_alloc(1, 0);
+_eval_tmp = caml_copy_int32($l2);
+Store_field($l1, 0, _eval_tmp);',
+  });
+  static final MARSHAL_UINT16 = baseExtend(BaseMarshal.baseUint16(), {
+    mlType: "value",
+    evalL1: MARSHAL_DIRECT,
+    l1Eval: MARSHAL_DIRECT,
+  }, {
+    l1l2: (l1, l2) -> '$l2 = Int32_val(Field($l1, 0));',
+    l2l1: (l2, l1) -> '$l1 = caml_alloc(1, 0);
+_eval_tmp = caml_copy_int32($l2);
+Store_field($l1, 0, _eval_tmp);',
+  });
+  static final MARSHAL_INT16 = baseExtend(BaseMarshal.baseInt16(), {
+    mlType: "value",
+    evalL1: MARSHAL_DIRECT,
+    l1Eval: MARSHAL_DIRECT,
+  }, {
+    l1l2: (l1, l2) -> '$l2 = Int32_val(Field($l1, 0));',
+    l2l1: (l2, l1) -> '$l1 = caml_alloc(1, 0);
+_eval_tmp = caml_copy_int32($l2);
+Store_field($l1, 0, _eval_tmp);',
+  });
+  static final MARSHAL_UINT32 = baseExtend(BaseMarshal.baseUint32(), {
+    mlType: "value",
+    evalL1: MARSHAL_DIRECT,
+    l1Eval: MARSHAL_DIRECT,
+  }, {
+    l1l2: (l1, l2) -> '$l2 = Int32_val(Field($l1, 0));',
+    l2l1: (l2, l1) -> '$l1 = caml_alloc(1, 0);
+_eval_tmp = caml_copy_int32($l2);
+Store_field($l1, 0, _eval_tmp);',
+  });
+  static final MARSHAL_INT32 = baseExtend(BaseMarshal.baseInt32(), {
+    mlType: "value",
+    evalL1: MARSHAL_DIRECT,
+    l1Eval: MARSHAL_DIRECT,
+  }, {
+    l1l2: (l1, l2) -> '$l2 = Int32_val(Field($l1, 0));',
+    l2l1: (l2, l1) -> '$l1 = caml_alloc(1, 0);
+_eval_tmp = caml_copy_int32($l2);
+Store_field($l1, 0, _eval_tmp);',
+  });
+  public function uint8():EvalTypeMarshal return MARSHAL_UINT8;
+  public function int8():EvalTypeMarshal return MARSHAL_INT8;
+  public function uint16():EvalTypeMarshal return MARSHAL_UINT16;
+  public function int16():EvalTypeMarshal return MARSHAL_INT16;
+  public function uint32():EvalTypeMarshal return MARSHAL_UINT32;
+  public function int32():EvalTypeMarshal return MARSHAL_INT32;
+
+  static final MARSHAL_UINT64 = baseExtend(BaseMarshal.baseUint64(), {
+    mlType: "int64",
+    evalL1: (eval) -> '(decode_haxe_i64_fix ($eval))',
+    l1Eval: (l1) -> '(encode_haxe_i64_direct ($l1))',
+  }, {
+    l1l2: (l1, l2) -> '$l2 = Int64_val($l1);',
+    l2l1: (l2, l1) -> '$l1 = caml_copy_int64($l2);',
+  });
+  static final MARSHAL_INT64 = baseExtend(BaseMarshal.baseInt64(), {
+    mlType: "int64",
+    evalL1: (eval) -> '(decode_haxe_i64_fix ($eval))',
+    l1Eval: (l1) -> '(encode_haxe_i64_direct ($l1))',
+  }, {
+    l1l2: (l1, l2) -> '$l2 = Int64_val($l1);',
+    l2l1: (l2, l1) -> '$l1 = caml_copy_int64($l2);',
+  });
+  public function uint64():EvalTypeMarshal return MARSHAL_UINT64;
+  public function int64():EvalTypeMarshal return MARSHAL_INT64;
+
+  static final MARSHAL_FLOAT64 = baseExtend(BaseMarshal.baseFloat64(), {
+    mlType: "value",
+    evalL1: MARSHAL_DIRECT,
+    l1Eval: MARSHAL_DIRECT,
+  }, {
+    l1l2: (l1, l2) -> '$l2 = Tag_val($l1) == 0 ? ((double)Int32_val(Field($l1, 0))) : Double_val(Field($l1, 0));',
+    l2l1: (l2, l1) -> '$l1 = caml_alloc(1, 1);
+_eval_tmp = caml_copy_double($l2);
+Store_field($l1, 0, _eval_tmp);',
+  });
+  public function float32():EvalTypeMarshal return throw "!";
+  public function float64():EvalTypeMarshal return MARSHAL_FLOAT64;
+
+  static final MARSHAL_STRING = baseExtend(BaseMarshal.baseString(), {
+    mlType: "Extlib_leftovers.UTF8.t",
+    evalL1: (eval) -> '(decode_string ($eval))',
+    l1Eval: (l1) -> '(encode_string ($l1))',
+  }, {
+    l1l2: (l1, l2) -> '$l2 = String_val($l1);',
+    l2l1: (l2, l1) -> '$l1 = caml_copy_string($l2);',
+  });
+  public function string():EvalTypeMarshal return MARSHAL_STRING;
+
+  static final MARSHAL_BYTES = baseExtend(BaseMarshal.baseBytesInternal(), {
+    mlType: "value",
+      evalL1: MARSHAL_DIRECT,
+      l1Eval: MARSHAL_DIRECT,
+  }, {
+    haxeType: (macro : eval.integers.UInt64),
+    l1l2: (l1, l2) -> '$l2 = (uint8_t*)Int64_val(Field($l1, 0));',
+    l2l1: (l2, l1) -> '$l1 = caml_alloc(1, 15);
+_eval_tmp = caml_copy_int64((uint64_t)$l2);
+Store_field($l1, 0, _eval_tmp);',
+  });
+  function bytesInternalType():EvalTypeMarshal return MARSHAL_BYTES;
+  function bytesInternalOps(
+    alloc:(size:Expr)->Expr,
+    blit:(source:Expr, srcpos:Expr, dest:Expr, dstpost:Expr, size:Expr)->Expr
+  ):{
+    toHaxeCopy:(self:Expr, size:Expr)->Expr,
+    fromHaxeCopy:(bytes:Expr)->Expr,
+    toHaxeRef:Null<(self:Expr, size:Expr)->Expr>,
+    fromHaxeRef:Null<(bytes:Expr)->Expr>,
+  } {
+    //var pathBytesRef = baseBytesRef(
+    //  (macro : eval.integers.UInt64), macro 0,
+    //  (macro : Int), macro 0, // handle unused
+    //  macro {}
+    //);
+    return {
+      toHaxeCopy: (self, size) -> macro {
+        var _self = ($self : eval.integers.UInt64);
+        var _size = ($size : Int);
+        var _ret = ((untyped $e{library.fieldExpr("_ammer_native")}._ammer_eval_tohaxecopy) : (eval.integers.UInt64, Int) -> haxe.io.Bytes)(
+          _self,
+          _size
+        );
+        (_ret : haxe.io.Bytes);
+      },
+      fromHaxeCopy: (bytes) -> macro {
+        var _bytes = ($bytes : haxe.io.Bytes);
+        var _ret = ((untyped $e{library.fieldExpr("_ammer_native")}._ammer_eval_fromhaxecopy) : (haxe.io.Bytes, Int) -> eval.integers.UInt64)(
+          _bytes,
+          _bytes.length
+        );
+        (_ret : eval.integers.UInt64);
+      },
+
+      toHaxeRef: null,
+      fromHaxeRef: null,
+    };
+  }
+
+  function opaqueInternal(name:String):EvalTypeMarshal {
+    var mname = Mangle.identifier(name);
+    return baseExtend(BaseMarshal.baseOpaqueInternal(name), {
+      mlType: "value",
+      evalL1: MARSHAL_DIRECT,
+      l1Eval: MARSHAL_DIRECT,
+    }, {
+      haxeType: (macro : eval.integers.UInt64),
+      l1l2: (l1, l2) -> '$l2 = ($name)Int64_val(Field($l1, 0));',
+      l2l1: (l2, l1) -> '$l1 = caml_alloc(1, 15);
+_eval_tmp = caml_copy_int64((uint64_t)$l2);
+Store_field($l1, 0, _eval_tmp);',
+    });
+  }
+
+  function structPtrDerefInternal(name:String):EvalTypeMarshal {
+    var mname = Mangle.identifier('$name*');
+    return baseExtend(BaseMarshal.baseStructPtrDerefInternal(name), {
+      mlType: "value",
+      evalL1: MARSHAL_DIRECT,
+      l1Eval: MARSHAL_DIRECT,
+    }, {
+      haxeType: (macro : eval.integers.UInt64),
+      l1l2: (l1, l2) -> '$l2 = ($name*)Int64_val(Field($l1, 0));',
+      l2l1: (l2, l1) -> '$l1 = caml_alloc(1, 15);
+_eval_tmp = caml_copy_int64((uint64_t)$l2);
+Store_field($l1, 0, _eval_tmp);',
+    });
+  }
+
+  function arrayPtrInternalType(element:EvalTypeMarshal):EvalTypeMarshal return baseExtend(BaseMarshal.baseArrayPtrInternal(element), {
+    mlType: "value",
+    evalL1: MARSHAL_DIRECT,
+    l1Eval: MARSHAL_DIRECT,
+  }, {
+    haxeType: (macro : eval.integers.UInt64),
+      l1l2: (l1, l2) -> '$l2 = (${element.l2Type}*)Int64_val(Field($l1, 0));',
+      l2l1: (l2, l1) -> '$l1 = caml_alloc(1, 15);
+_eval_tmp = caml_copy_int64((uint64_t)$l2);
+Store_field($l1, 0, _eval_tmp);',
+  });
+
+  function haxePtrInternal(haxeType:ComplexType):MarshalHaxe<EvalTypeMarshal> {
+    var ret = baseHaxePtrInternal(
+      haxeType,
+      (macro : eval.integers.UInt64),
+      macro eval.integers.UInt64.ZERO,
+      macro ((untyped $e{library.fieldExpr("_ammer_native")}._ammer_ref_getvalue) : (eval.integers.UInt64) -> $haxeType)(handle),
+      macro ((untyped $e{library.fieldExpr("_ammer_native")}._ammer_ref_getcount) : (eval.integers.UInt64) -> Int)(handle),
+      rc -> macro ((untyped $e{library.fieldExpr("_ammer_native")}._ammer_ref_setcount) : (eval.integers.UInt64, Int) -> Void)(handle, $rc),
+      value -> macro ((untyped $e{library.fieldExpr("_ammer_native")}._ammer_ref_create) : ($haxeType) -> eval.integers.UInt64)($value),
+      macro ((untyped $e{library.fieldExpr("_ammer_native")}._ammer_ref_delete) : (eval.integers.UInt64) -> Void)(handle),
+      null,
+      // comparison of eval.integers.UInt64 values does not work properly, so
+      // a null value (VNull) is used to indicate a null pointer
+      handle -> macro $handle == null || $handle == eval.integers.UInt64.ZERO
+    );
+    TypeUtils.defineType(ret.tdef);
+    return ret.marshal;
+  }
+
+  function haxePtrInternalType(haxeType:ComplexType):EvalTypeMarshal return baseExtend(BaseMarshal.baseHaxePtrInternalType(haxeType), {
+    mlType: "value",
+    evalL1: MARSHAL_DIRECT,
+    l1Eval: MARSHAL_DIRECT,
+  }, {
+    haxeType: (macro : eval.integers.UInt64),
+    l1l2: (l1, l2) -> '$l2 = (_ammer_haxe_ref*)Int64_val(Field($l1, 0));',
+    l2l1: (l2, l1) -> 'if ($l2 == NULL) {
+  $l1 = Val_int(0);
+} else {
+  $l1 = caml_alloc(1, 15);
+  _eval_tmp = caml_copy_int64((uint64_t)$l2);
+  Store_field($l1, 0, _eval_tmp);
+}',
+  });
+
+  public function new(library:EvalLibrary) {
+    super(library);
+  }
+}
+
+#end

--- a/src/ammer/core/plat/Eval.hx
+++ b/src/ammer/core/plat/Eval.hx
@@ -39,6 +39,8 @@ class Eval extends Base<
     var ops:Array<BuildOp> = [];
     for (lib in libraries) {
       // TODO: avoid clashes in the Haxe plugins directory somehow
+      ops.push(BOAlways(File('${config.buildPath}/${lib.config.name}'), EnsureDirectory));
+      ops.push(BOAlways(File(config.outputPath), EnsureDirectory));
       ops.push(BOAlways(File('${config.haxeRepoPath}/plugins/ammer_core_${lib.config.name}/c'), EnsureDirectory));
       ops.push(BOAlways(File('${config.haxeRepoPath}/plugins/ammer_core_${lib.config.name}/ml'), EnsureDirectory));
       ops.push(BOAlways(

--- a/src/ammer/core/plat/Eval.hx
+++ b/src/ammer/core/plat/Eval.hx
@@ -45,6 +45,7 @@ class Eval extends Base<
       ops.push(BOAlways(File('${config.haxeRepoPath}/plugins/ammer_core_${lib.config.name}/ml'), EnsureDirectory));
       ops.push(BOAlways(
         File('${config.haxeRepoPath}/plugins/ammer_core_${lib.config.name}/dune'),
+        // TODO: support frameworks
         WriteContent('(data_only_dirs cmxs hx)
 (include_subdirs unqualified)
 (library

--- a/src/ammer/core/plat/Eval.hx
+++ b/src/ammer/core/plat/Eval.hx
@@ -2,12 +2,6 @@ package ammer.core.plat;
 
 #if macro
 
-import haxe.macro.Context;
-import haxe.macro.Expr;
-import ammer.core.utils.*;
-
-using Lambda;
-
 @:structInit
 class EvalConfig extends BaseConfig {
   public var haxeRepoPath:String;

--- a/src/ammer/core/plat/Eval.hx
+++ b/src/ammer/core/plat/Eval.hx
@@ -510,6 +510,16 @@ Store_field($l1, 0, _eval_tmp);',
   public function uint64():EvalTypeMarshal return MARSHAL_UINT64;
   public function int64():EvalTypeMarshal return MARSHAL_INT64;
 
+  static final MARSHAL_FLOAT32 = baseExtend(BaseMarshal.baseFloat64As32(), {
+    mlType: "value",
+    evalL1: MARSHAL_DIRECT,
+    l1Eval: MARSHAL_DIRECT,
+  }, {
+    l1l2: (l1, l2) -> '$l2 = Tag_val($l1) == 0 ? ((double)Int32_val(Field($l1, 0))) : Double_val(Field($l1, 0));',
+    l2l1: (l2, l1) -> '$l1 = caml_alloc(1, 1);
+_eval_tmp = caml_copy_double($l2);
+Store_field($l1, 0, _eval_tmp);',
+  });
   static final MARSHAL_FLOAT64 = baseExtend(BaseMarshal.baseFloat64(), {
     mlType: "value",
     evalL1: MARSHAL_DIRECT,
@@ -520,7 +530,7 @@ Store_field($l1, 0, _eval_tmp);',
 _eval_tmp = caml_copy_double($l2);
 Store_field($l1, 0, _eval_tmp);',
   });
-  public function float32():EvalTypeMarshal return throw "!";
+  public function float32():EvalTypeMarshal return MARSHAL_FLOAT32;
   public function float64():EvalTypeMarshal return MARSHAL_FLOAT64;
 
   static final MARSHAL_STRING = baseExtend(BaseMarshal.baseString(), {

--- a/src/ammer/core/plat/Hashlink.hx
+++ b/src/ammer/core/plat/Hashlink.hx
@@ -40,7 +40,6 @@ class Hashlink extends Base<
       includePaths: config.hlIncludePaths,
       libraryPaths: config.hlLibraryPaths,
       linkNames: [BuildProgram.useMSVC ? "libhl" : "hl"],
-      defines: lib -> ["LIBHL_EXPORTS"].concat(lib.config.defines),
       outputPath: lib -> config.hlc
         ? '${config.outputPath}/lib${lib.config.name}.%DLL%'
         : '${config.outputPath}/${lib.config.name}.hdll',

--- a/src/ammer/core/plat/Hashlink.hx
+++ b/src/ammer/core/plat/Hashlink.hx
@@ -457,7 +457,7 @@ hl_from_utf8((uchar*)$l1->data, $l1->len, $l2);', // TODO: handle null?
     };
   }
 
-  function opaqueInternal(name:String):MarshalOpaque<HashlinkTypeMarshal> {
+  function opaqueInternal(name:String):HashlinkTypeMarshal {
     var mname = Mangle.identifier(name);
     var haxeType:ComplexType = TPath({
       // no prefix results in collisions with other type declarations
@@ -466,18 +466,27 @@ hl_from_utf8((uchar*)$l1->data, $l1->len, $l2);', // TODO: handle null?
       pack: ["hl"],
       name: "Abstract",
     });
-    return {
-      type: baseExtend(BaseMarshal.baseOpaquePtrInternal(name), {
-        hlType: '_ABSTRACT(abstract_$mname)',
-      }, {
-        haxeType: haxeType,
-      }),
-      typeDeref: baseExtend(BaseMarshal.baseOpaqueDirectInternal(name), {
-        hlType: '_ABSTRACT(abstract_$mname)',
-      }, {
-        haxeType: haxeType,
-      }),
-    };
+    return baseExtend(BaseMarshal.baseOpaqueInternal(name), {
+      hlType: '_ABSTRACT(abstract_$mname)',
+    }, {
+      haxeType: haxeType,
+    });
+  }
+
+  function structPtrDerefInternal(name:String):HashlinkTypeMarshal {
+    var mname = Mangle.identifier('$name*');
+    var haxeType:ComplexType = TPath({
+      // no prefix results in collisions with other type declarations
+      // TODO: name with _ammer prefix
+      params: [TPExpr(macro $v{"abstract_" + mname})],
+      pack: ["hl"],
+      name: "Abstract",
+    });
+    return baseExtend(BaseMarshal.baseStructPtrDerefInternal(name), {
+      hlType: '_ABSTRACT(abstract_$mname)',
+    }, {
+      haxeType: haxeType,
+    });
   }
 
   function arrayPtrInternalType(element:HashlinkTypeMarshal):HashlinkTypeMarshal return baseExtend(BaseMarshal.baseArrayPtrInternal(element), {

--- a/src/ammer/core/plat/Hashlink.hx
+++ b/src/ammer/core/plat/Hashlink.hx
@@ -2,12 +2,6 @@ package ammer.core.plat;
 
 #if macro
 
-import haxe.macro.Context;
-import haxe.macro.Expr;
-import ammer.core.utils.*;
-
-using Lambda;
-
 @:structInit
 class HashlinkConfig extends BaseConfig {
   public var hlc:Bool = false;

--- a/src/ammer/core/plat/Hashlink.hx
+++ b/src/ammer/core/plat/Hashlink.hx
@@ -120,7 +120,7 @@ class HashlinkLibrary extends BaseLibrary<
 
 typedef struct { void* value; int32_t refcount; } _ammer_haxe_ref;
 HL_PRIM _ammer_haxe_ref* HL_NAME(_ammer_ref_create)(vdynamic* value) {
-  _ammer_haxe_ref* ref = ${config.mallocFunction}(sizeof(_ammer_haxe_ref));
+  _ammer_haxe_ref* ref = (_ammer_haxe_ref*)${config.mallocFunction}(sizeof(_ammer_haxe_ref));
   ref->value = value;
   ref->refcount = 0;
   hl_add_root(&ref->value);

--- a/src/ammer/core/plat/Hashlink.hx
+++ b/src/ammer/core/plat/Hashlink.hx
@@ -552,16 +552,20 @@ hl_from_utf8((uchar*)$l1->data, $l1->len, $l2);', // TODO: handle null?
     };
   }
 
-  function haxePtrInternal(haxeType:ComplexType):MarshalHaxe<HashlinkTypeMarshal> return baseHaxePtrInternal(
-    haxeType,
-    (macro : hl.Abstract<"abstract_haxe_ref">),
-    macro null,
-    macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_getvalue")})(handle),
-    macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_getcount")})(handle),
-    rc -> macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_setcount")})(handle, $rc),
-    value -> macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_create")})($value),
-    macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_delete")})(handle)
-  ).marshal;
+  function haxePtrInternal(haxeType:ComplexType):MarshalHaxe<HashlinkTypeMarshal> {
+    var ret = baseHaxePtrInternal(
+      haxeType,
+      (macro : hl.Abstract<"abstract_haxe_ref">),
+      macro null,
+      macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_getvalue")})(handle),
+      macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_getcount")})(handle),
+      rc -> macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_setcount")})(handle, $rc),
+      value -> macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_create")})($value),
+      macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_delete")})(handle)
+    );
+    TypeUtils.defineType(ret.tdef);
+    return ret.marshal;
+  }
 
   function haxePtrInternalType(haxeType:ComplexType):HashlinkTypeMarshal return baseExtend(BaseMarshal.baseHaxePtrInternalType(haxeType), {
     hlType: "_ABSTRACT(abstract_haxe_ref)",

--- a/src/ammer/core/plat/Hashlink.hx
+++ b/src/ammer/core/plat/Hashlink.hx
@@ -46,7 +46,7 @@ class Hashlink extends Base<
       includePaths: config.hlIncludePaths,
       libraryPaths: config.hlLibraryPaths,
       linkNames: [BuildProgram.useMSVC ? "libhl" : "hl"],
-      defines: ["LIBHL_EXPORTS"],
+      defines: lib -> ["LIBHL_EXPORTS"].concat(lib.config.defines),
       outputPath: lib -> config.hlc
         ? '${config.outputPath}/lib${lib.config.name}.%DLL%'
         : '${config.outputPath}/${lib.config.name}.hdll',

--- a/src/ammer/core/plat/Hashlink.hx
+++ b/src/ammer/core/plat/Hashlink.hx
@@ -26,6 +26,7 @@ typedef HashlinkTypeMarshal = {
 };
 
 class Hashlink extends Base<
+  Hashlink,
   HashlinkConfig,
   HashlinkLibraryConfig,
   HashlinkTypeMarshal,
@@ -34,6 +35,10 @@ class Hashlink extends Base<
 > {
   public function new(config:HashlinkConfig) {
     super("hl", config);
+  }
+
+  public function createLibrary(libConfig:HashlinkLibraryConfig):HashlinkLibrary {
+    return new HashlinkLibrary(this, libConfig);
   }
 
   public function finalise():BuildProgram {
@@ -52,6 +57,7 @@ class Hashlink extends Base<
 @:allow(ammer.core.plat)
 class HashlinkLibrary extends BaseLibrary<
   HashlinkLibrary,
+  Hashlink,
   HashlinkConfig,
   HashlinkLibraryConfig,
   HashlinkTypeMarshal,
@@ -74,8 +80,8 @@ class HashlinkLibrary extends BaseLibrary<
     });
   }
 
-  public function new(config:HashlinkLibraryConfig) {
-    super(config, new HashlinkMarshal(this));
+  public function new(platform:Hashlink, config:HashlinkLibraryConfig) {
+    super(platform, config, new HashlinkMarshal(this));
 
     #if (haxe >= version("4.2.6") && hl_ver >= version("1.12.0") && !hl_legacy32)
     pushNative("_ammer_init",         (macro : (String) -> Void), config.pos);
@@ -288,6 +294,7 @@ DEFINE_PRIM(_VOID, _ammer_init, _OBJ(_I32 _I32) _OBJ(_BYTES _I32));');
 @:allow(ammer.core.plat)
 class HashlinkMarshal extends BaseMarshal<
   HashlinkMarshal,
+  Hashlink,
   HashlinkConfig,
   HashlinkLibraryConfig,
   HashlinkLibrary,

--- a/src/ammer/core/plat/Java.hx
+++ b/src/ammer/core/plat/Java.hx
@@ -512,26 +512,25 @@ class JavaMarshal extends BaseMarshal<
     };
   }
 
-  function opaqueInternal(name:String):MarshalOpaque<JavaTypeMarshal> return {
-    type: baseExtend(BaseMarshal.baseOpaquePtrInternal(name), {
-      primitive: true,
-      javaMangle: "J",
-    }, {
-      haxeType: (macro : haxe.Int64),
-      l1Type: "jlong",
-      l1l2: BaseMarshal.MARSHAL_CONVERT_CAST('$name*'),
-      l2l1: BaseMarshal.MARSHAL_CONVERT_CAST("jlong"),
-    }),
-    typeDeref: baseExtend(BaseMarshal.baseOpaqueDirectInternal(name), {
-      primitive: true,
-      javaMangle: "J",
-    }, {
-      haxeType: (macro : haxe.Int64),
-      l1Type: "jlong",
-      l1l2: BaseMarshal.MARSHAL_CONVERT_CAST('$name*'),
-      l2l1: BaseMarshal.MARSHAL_CONVERT_CAST("jlong"),
-    }),
-  };
+  function opaqueInternal(name:String):JavaTypeMarshal return baseExtend(BaseMarshal.baseOpaqueInternal(name), {
+    primitive: true,
+    javaMangle: "J",
+  }, {
+    haxeType: (macro : haxe.Int64),
+    l1Type: "jlong",
+    l1l2: BaseMarshal.MARSHAL_CONVERT_CAST(name),
+    l2l1: BaseMarshal.MARSHAL_CONVERT_CAST("jlong"),
+  });
+
+  function structPtrDerefInternal(name:String):JavaTypeMarshal return baseExtend(BaseMarshal.baseStructPtrDerefInternal(name), {
+    primitive: true,
+    javaMangle: "J",
+  }, {
+    haxeType: (macro : haxe.Int64),
+    l1Type: "jlong",
+    l1l2: BaseMarshal.MARSHAL_CONVERT_CAST('$name*'),
+    l2l1: BaseMarshal.MARSHAL_CONVERT_CAST("jlong"),
+  });
 
   function arrayPtrInternalType(element:JavaTypeMarshal):JavaTypeMarshal return baseExtend(BaseMarshal.baseArrayPtrInternal(element), {
     primitive: false,

--- a/src/ammer/core/plat/Java.hx
+++ b/src/ammer/core/plat/Java.hx
@@ -514,7 +514,7 @@ class JavaMarshal extends BaseMarshal<
 
   function opaqueInternal(name:String):MarshalOpaque<JavaTypeMarshal> return {
     type: baseExtend(BaseMarshal.baseOpaquePtrInternal(name), {
-      primitive: false,
+      primitive: true,
       javaMangle: "J",
     }, {
       haxeType: (macro : haxe.Int64),
@@ -523,7 +523,7 @@ class JavaMarshal extends BaseMarshal<
       l2l1: BaseMarshal.MARSHAL_CONVERT_CAST("jlong"),
     }),
     typeDeref: baseExtend(BaseMarshal.baseOpaqueDirectInternal(name), {
-      primitive: false,
+      primitive: true,
       javaMangle: "J",
     }, {
       haxeType: (macro : haxe.Int64),
@@ -670,19 +670,23 @@ JNIEXPORT void ${library.javaMangle(unrefFrom)}(JNIEnv *_java_env, jclass _java_
     };
   }
 
-  function haxePtrInternal(haxeType:ComplexType):MarshalHaxe<JavaTypeMarshal> return baseHaxePtrInternal(
-    haxeType,
-    (macro : haxe.Int64),
-    macro 0,
-    macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_getvalue")})(handle),
-    macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_getcount")})(handle),
-    rc -> macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_setcount")})(handle, $rc),
-    value -> macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_create")})($value),
-    macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_delete")})(handle)
-  ).marshal;
+  function haxePtrInternal(haxeType:ComplexType):MarshalHaxe<JavaTypeMarshal> {
+    var ret = baseHaxePtrInternal(
+      haxeType,
+      (macro : haxe.Int64),
+      macro 0,
+      macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_getvalue")})(handle),
+      macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_getcount")})(handle),
+      rc -> macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_setcount")})(handle, $rc),
+      value -> macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_create")})($value),
+      macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_delete")})(handle)
+    );
+    TypeUtils.defineType(ret.tdef);
+    return ret.marshal;
+  }
 
   function haxePtrInternalType(haxeType:ComplexType):JavaTypeMarshal return baseExtend(BaseMarshal.baseHaxePtrInternalType(haxeType), {
-    primitive: false, // TODO: why? (same in opaque ptr)
+    primitive: true,
     javaMangle: "J",
   }, {
     haxeType: (macro : haxe.Int64),

--- a/src/ammer/core/plat/Java.hx
+++ b/src/ammer/core/plat/Java.hx
@@ -2,13 +2,6 @@ package ammer.core.plat;
 
 #if macro
 
-import haxe.macro.Context;
-import haxe.macro.Expr;
-import ammer.core.utils.*;
-
-using StringTools;
-using Lambda;
-
 @:structInit
 class JavaConfig extends BaseConfig {
   public var javaIncludePaths:Array<String> = null;

--- a/src/ammer/core/plat/Java.hx
+++ b/src/ammer/core/plat/Java.hx
@@ -30,6 +30,7 @@ typedef JavaTypeMarshal = {
 };
 
 class Java extends Base<
+  Java,
   JavaConfig,
   JavaLibraryConfig,
   JavaTypeMarshal,
@@ -38,6 +39,10 @@ class Java extends Base<
 > {
   public function new(config:JavaConfig) {
     super("java", config);
+  }
+
+  public function createLibrary(libConfig:JavaLibraryConfig):JavaLibrary {
+    return new JavaLibrary(this, libConfig);
   }
 
   public function finalise():BuildProgram {
@@ -51,6 +56,7 @@ class Java extends Base<
 @:allow(ammer.core.plat)
 class JavaLibrary extends BaseLibrary<
   JavaLibrary,
+  Java,
   JavaConfig,
   JavaLibraryConfig,
   JavaTypeMarshal,
@@ -69,8 +75,8 @@ class JavaLibrary extends BaseLibrary<
     });
   }
 
-  public function new(config:JavaLibraryConfig) {
-    super(config, new JavaMarshal(this));
+  public function new(platform:Java, config:JavaLibraryConfig) {
+    super(platform, config, new JavaMarshal(this));
     tdef.meta.push({
       pos: config.pos,
       name: ":nativeGen",
@@ -340,6 +346,7 @@ jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 @:allow(ammer.core.plat)
 class JavaMarshal extends BaseMarshal<
   JavaMarshal,
+  Java,
   JavaConfig,
   JavaLibraryConfig,
   JavaLibrary,

--- a/src/ammer/core/plat/Java.hx
+++ b/src/ammer/core/plat/Java.hx
@@ -130,7 +130,7 @@ JNIEXPORT void ${javaMangle("_ammer_java_frombytesunref")}(JNIEnv *_java_env, jc
 
 typedef struct { jobject value; int32_t refcount; } _ammer_haxe_ref;
 JNIEXPORT jlong ${javaMangle("_ammer_ref_create")}(JNIEnv *_java_env, jclass _java_cls, jobject value) {
-  _ammer_haxe_ref* ref = ${config.mallocFunction}(sizeof(_ammer_haxe_ref));
+  _ammer_haxe_ref* ref = (_ammer_haxe_ref*)${config.mallocFunction}(sizeof(_ammer_haxe_ref));
   ref->value = (*_java_env)->NewGlobalRef(_java_env, value);
   ref->refcount = 0;
   return (jlong)ref;

--- a/src/ammer/core/plat/Lua.hx
+++ b/src/ammer/core/plat/Lua.hx
@@ -19,6 +19,7 @@ typedef LuaLibraryConfig = LibraryConfig;
 typedef LuaTypeMarshal = BaseTypeMarshal;
 
 class Lua extends Base<
+  Lua,
   LuaConfig,
   LuaLibraryConfig,
   LuaTypeMarshal,
@@ -27,6 +28,10 @@ class Lua extends Base<
 > {
   public function new(config:LuaConfig) {
     super("lua", config);
+  }
+
+  public function createLibrary(libConfig:LuaLibraryConfig):LuaLibrary {
+    return new LuaLibrary(this, libConfig);
   }
 
   public function finalise():BuildProgram {
@@ -42,6 +47,7 @@ class Lua extends Base<
 @:allow(ammer.core.plat)
 class LuaLibrary extends BaseLibrary<
   LuaLibrary,
+  Lua,
   LuaConfig,
   LuaLibraryConfig,
   LuaTypeMarshal,
@@ -49,8 +55,8 @@ class LuaLibrary extends BaseLibrary<
 > {
   var lbInit = new LineBuf();
 
-  public function new(config:LuaLibraryConfig) {
-    super(config, new LuaMarshal(this));
+  public function new(platform:Lua, config:LuaLibraryConfig) {
+    super(platform, config, new LuaMarshal(this));
     tdef.fields.push({
       pos: config.pos,
       name: "_ammer_native",
@@ -287,6 +293,7 @@ lua_gettable(_lua_state, -2);')
 @:allow(ammer.core.plat)
 class LuaMarshal extends BaseMarshal<
   LuaMarshal,
+  Lua,
   LuaConfig,
   LuaLibraryConfig,
   LuaLibrary,

--- a/src/ammer/core/plat/Lua.hx
+++ b/src/ammer/core/plat/Lua.hx
@@ -492,16 +492,20 @@ lua_setfield(_lua_state, -2, "high");'),
     l2l1: MARSHAL_PUSH((l2) -> 'lua_pushlightuserdata(_lua_state, $l2);'),
   });
 
-  function haxePtrInternal(haxeType:ComplexType):MarshalHaxe<LuaTypeMarshal> return baseHaxePtrInternal(
-    haxeType,
-    (macro : lua.UserData),
-    macro null,
-    macro ((untyped $e{library.fieldExpr("_ammer_native")}["_ammer_ref_getvalue"]) : (lua.UserData) -> $haxeType)(handle),
-    macro ((untyped $e{library.fieldExpr("_ammer_native")}["_ammer_ref_getcount"]) : (lua.UserData) -> Int)(handle),
-    rc -> macro ((untyped $e{library.fieldExpr("_ammer_native")}["_ammer_ref_setcount"]) : (lua.UserData, Int) -> Void)(handle, $rc),
-    value -> macro ((untyped $e{library.fieldExpr("_ammer_native")}["_ammer_ref_create"]) : ($haxeType) -> lua.UserData)($value),
-    macro ((untyped $e{library.fieldExpr("_ammer_native")}["_ammer_ref_delete"]) : (lua.UserData) -> Void)(handle)
-  ).marshal;
+  function haxePtrInternal(haxeType:ComplexType):MarshalHaxe<LuaTypeMarshal> {
+    var ret = baseHaxePtrInternal(
+      haxeType,
+      (macro : lua.UserData),
+      macro null,
+      macro ((untyped $e{library.fieldExpr("_ammer_native")}["_ammer_ref_getvalue"]) : (lua.UserData) -> $haxeType)(handle),
+      macro ((untyped $e{library.fieldExpr("_ammer_native")}["_ammer_ref_getcount"]) : (lua.UserData) -> Int)(handle),
+      rc -> macro ((untyped $e{library.fieldExpr("_ammer_native")}["_ammer_ref_setcount"]) : (lua.UserData, Int) -> Void)(handle, $rc),
+      value -> macro ((untyped $e{library.fieldExpr("_ammer_native")}["_ammer_ref_create"]) : ($haxeType) -> lua.UserData)($value),
+      macro ((untyped $e{library.fieldExpr("_ammer_native")}["_ammer_ref_delete"]) : (lua.UserData) -> Void)(handle)
+    );
+    TypeUtils.defineType(ret.tdef);
+    return ret.marshal;
+  }
 
   function haxePtrInternalType(haxeType:ComplexType):LuaTypeMarshal return baseExtend(BaseMarshal.baseHaxePtrInternalType(haxeType), {
     haxeType: (macro : lua.UserData),

--- a/src/ammer/core/plat/Lua.hx
+++ b/src/ammer/core/plat/Lua.hx
@@ -406,15 +406,15 @@ lua_setfield(_lua_state, -2, "high");'),
   public function uint64():LuaTypeMarshal return MARSHAL_UINT64;
   public function int64():LuaTypeMarshal return MARSHAL_INT64;
 
-  // static final MARSHAL_FLOAT32 = baseExtend(BaseMarshal.baseFloat32(), {
-  //   l1l2: (l1, l2) -> '$l2 = lua_tonumber(_lua_state, $l1);',
-  //   l2l1: (l2, l1) -> 'lua_pushnumber(_lua_state, $l2);',
-  // });
+  static final MARSHAL_FLOAT32 = baseExtend(BaseMarshal.baseFloat64As32(), {
+    l1l2: (l1, l2) -> '$l2 = lua_tonumber(_lua_state, $l1);',
+    l2l1: MARSHAL_PUSH((l2) -> 'lua_pushnumber(_lua_state, $l2);'),
+  });
   static final MARSHAL_FLOAT64 = baseExtend(BaseMarshal.baseFloat64(), {
     l1l2: (l1, l2) -> '$l2 = lua_tonumber(_lua_state, $l1);',
     l2l1: MARSHAL_PUSH((l2) -> 'lua_pushnumber(_lua_state, $l2);'),
   });
-  public function float32():LuaTypeMarshal throw "!";
+  public function float32():LuaTypeMarshal return MARSHAL_FLOAT32;
   public function float64():LuaTypeMarshal return MARSHAL_FLOAT64;
 
   static final MARSHAL_STRING = baseExtend(BaseMarshal.baseString(), {

--- a/src/ammer/core/plat/Lua.hx
+++ b/src/ammer/core/plat/Lua.hx
@@ -473,18 +473,17 @@ lua_setfield(_lua_state, -2, "high");'),
     };
   }
 
-  function opaqueInternal(name:String):MarshalOpaque<LuaTypeMarshal> return {
-    type: baseExtend(BaseMarshal.baseOpaquePtrInternal(name), {
-      haxeType: (macro : lua.UserData),
-      l1l2: (l1, l2) -> '$l2 = lua_touserdata(_lua_state, $l1);',
-      l2l1: MARSHAL_PUSH((l2) -> 'lua_pushlightuserdata(_lua_state, $l2);'),
-    }),
-    typeDeref: baseExtend(BaseMarshal.baseOpaqueDirectInternal(name), {
-      haxeType: (macro : lua.UserData),
-      l1l2: (l1, l2) -> '$l2 = lua_touserdata(_lua_state, $l1);',
-      l2l1: MARSHAL_PUSH((l2) -> 'lua_pushlightuserdata(_lua_state, $l2);'),
-    }),
-  };
+  function opaqueInternal(name:String):LuaTypeMarshal return baseExtend(BaseMarshal.baseOpaqueInternal(name), {
+    haxeType: (macro : lua.UserData),
+    l1l2: (l1, l2) -> '$l2 = lua_touserdata(_lua_state, $l1);',
+    l2l1: MARSHAL_PUSH((l2) -> 'lua_pushlightuserdata(_lua_state, $l2);'),
+  });
+
+  function structPtrDerefInternal(name:String):LuaTypeMarshal return baseExtend(BaseMarshal.baseStructPtrDerefInternal(name), {
+    haxeType: (macro : lua.UserData),
+    l1l2: (l1, l2) -> '$l2 = lua_touserdata(_lua_state, $l1);',
+    l2l1: MARSHAL_PUSH((l2) -> 'lua_pushlightuserdata(_lua_state, $l2);'),
+  });
 
   function arrayPtrInternalType(element:LuaTypeMarshal):LuaTypeMarshal return baseExtend(BaseMarshal.baseArrayPtrInternal(element), {
     haxeType: (macro : lua.UserData),

--- a/src/ammer/core/plat/Lua.hx
+++ b/src/ammer/core/plat/Lua.hx
@@ -89,7 +89,7 @@ static int _ammer_ref_create(lua_State* _lua_state) {
   lua_pushinteger(_lua_state, idx);
   lua_pushvalue(_lua_state, 1);
   lua_settable(_lua_state, -3);
-  _ammer_haxe_ref* ref = ${config.mallocFunction}(sizeof(_ammer_haxe_ref));
+  _ammer_haxe_ref* ref = (_ammer_haxe_ref*)${config.mallocFunction}(sizeof(_ammer_haxe_ref));
   ref->value = idx;
   ref->refcount = 0;
   lua_pushlightuserdata(_lua_state, ref);

--- a/src/ammer/core/plat/Lua.hx
+++ b/src/ammer/core/plat/Lua.hx
@@ -2,12 +2,6 @@ package ammer.core.plat;
 
 #if macro
 
-import haxe.macro.Context;
-import haxe.macro.Expr;
-import ammer.core.utils.*;
-
-using Lambda;
-
 @:structInit
 class LuaConfig extends BaseConfig {
   public var luaIncludePaths:Array<String> = null;

--- a/src/ammer/core/plat/Neko.hx
+++ b/src/ammer/core/plat/Neko.hx
@@ -118,7 +118,7 @@ DEFINE_PRIM(_ammer_neko_fromhaxeref, 1);
 
 typedef struct { value* data; int32_t refcount; } _ammer_haxe_ref;
 static value _ammer_ref_create(value obj) {
-  _ammer_haxe_ref* ref = ${config.mallocFunction}(sizeof(_ammer_haxe_ref));
+  _ammer_haxe_ref* ref = (_ammer_haxe_ref*)${config.mallocFunction}(sizeof(_ammer_haxe_ref));
   // TODO: remove double allocation?
   ref->data = alloc_root(1);
   *ref->data = obj;

--- a/src/ammer/core/plat/Neko.hx
+++ b/src/ammer/core/plat/Neko.hx
@@ -485,24 +485,30 @@ alloc_field($l1, _ammer_haxe_field_string, alloc_string($l2));',
     };
   }
 
-  function opaqueInternal(name:String):MarshalOpaque<NekoTypeMarshal> {
+  function opaqueInternal(name:String):NekoTypeMarshal {
     var mname = Mangle.identifier(name);
     if (!library.abstractKinds.exists(name)) {
       library.lb.ail('DEFINE_KIND(_neko_abstract_kind_$mname);');
       library.abstractKinds[name] = true;
     }
-    return {
-      type: baseExtend(BaseMarshal.baseOpaquePtrInternal(name), {
-        haxeType: (macro : Dynamic),
-        l1l2: (l1, l2) -> '$l2 = ($name*)(int_val)val_data($l1);',
-        l2l1: (l2, l1) -> '$l1 = alloc_abstract(_neko_abstract_kind_$mname, (value)(int_val)($l2));',
-      }),
-      typeDeref: baseExtend(BaseMarshal.baseOpaqueDirectInternal(name), {
-        haxeType: (macro : Dynamic),
-        l1l2: (l1, l2) -> '$l2 = ($name*)(int_val)val_data($l1);',
-        l2l1: (l2, l1) -> '$l1 = alloc_abstract(_neko_abstract_kind_$mname, (value)(int_val)($l2));',
-      }),
-    };
+    return baseExtend(BaseMarshal.baseOpaqueInternal(name), {
+      haxeType: (macro : Dynamic),
+      l1l2: (l1, l2) -> '$l2 = ($name*)(int_val)val_data($l1);',
+      l2l1: (l2, l1) -> '$l1 = alloc_abstract(_neko_abstract_kind_$mname, (value)(int_val)($l2));',
+    });
+  }
+
+  function structPtrDerefInternal(name:String):NekoTypeMarshal {
+    var mname = Mangle.identifier('$name*');
+    if (!library.abstractKinds.exists('$name*')) {
+      library.lb.ail('DEFINE_KIND(_neko_abstract_kind_$mname);');
+      library.abstractKinds['$name*'] = true;
+    }
+    return baseExtend(BaseMarshal.baseStructPtrDerefInternal(name), {
+      haxeType: (macro : Dynamic),
+      l1l2: (l1, l2) -> '$l2 = ($name*)(int_val)val_data($l1);',
+      l2l1: (l2, l1) -> '$l1 = alloc_abstract(_neko_abstract_kind_$mname, (value)(int_val)($l2));',
+    });
   }
 
   function arrayPtrInternalType(element:NekoTypeMarshal):NekoTypeMarshal {

--- a/src/ammer/core/plat/Neko.hx
+++ b/src/ammer/core/plat/Neko.hx
@@ -2,12 +2,6 @@ package ammer.core.plat;
 
 #if macro
 
-import haxe.macro.Context;
-import haxe.macro.Expr;
-import ammer.core.utils.*;
-
-using Lambda;
-
 @:structInit
 class NekoConfig extends BaseConfig {
   public var nekoIncludePaths:Array<String> = null;

--- a/src/ammer/core/plat/Neko.hx
+++ b/src/ammer/core/plat/Neko.hx
@@ -518,16 +518,20 @@ alloc_field($l1, _ammer_haxe_field_string, alloc_string($l2));',
     });
   }
 
-  function haxePtrInternal(haxeType:ComplexType):MarshalHaxe<NekoTypeMarshal> return baseHaxePtrInternal(
-    haxeType,
-    (macro : Dynamic),
-    macro null,
-    macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_getvalue")})(handle),
-    macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_getcount")})(handle),
-    rc -> macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_setcount")})(handle, $rc),
-    value -> macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_create")})($value),
-    macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_delete")})(handle)
-  ).marshal;
+  function haxePtrInternal(haxeType:ComplexType):MarshalHaxe<NekoTypeMarshal> {
+    var ret = baseHaxePtrInternal(
+      haxeType,
+      (macro : Dynamic),
+      macro null,
+      macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_getvalue")})(handle),
+      macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_getcount")})(handle),
+      rc -> macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_setcount")})(handle, $rc),
+      value -> macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_create")})($value),
+      macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_delete")})(handle)
+    );
+    TypeUtils.defineType(ret.tdef);
+    return ret.marshal;
+  }
 
   function haxePtrInternalType(haxeType:ComplexType):NekoTypeMarshal return baseExtend(BaseMarshal.baseHaxePtrInternalType(haxeType), {
     haxeType: (macro : Dynamic),

--- a/src/ammer/core/plat/Neko.hx
+++ b/src/ammer/core/plat/Neko.hx
@@ -19,6 +19,7 @@ typedef NekoLibraryConfig = LibraryConfig;
 typedef NekoTypeMarshal = BaseTypeMarshal;
 
 class Neko extends Base<
+  Neko,
   NekoConfig,
   NekoLibraryConfig,
   NekoTypeMarshal,
@@ -27,6 +28,10 @@ class Neko extends Base<
 > {
   public function new(config:NekoConfig) {
     super("neko", config);
+  }
+
+  public function createLibrary(libConfig:NekoLibraryConfig):NekoLibrary {
+    return new NekoLibrary(this, libConfig);
   }
 
   public function finalise():BuildProgram {
@@ -42,6 +47,7 @@ class Neko extends Base<
 @:allow(ammer.core.plat)
 class NekoLibrary extends BaseLibrary<
   NekoLibrary,
+  Neko,
   NekoConfig,
   NekoLibraryConfig,
   NekoTypeMarshal,
@@ -61,8 +67,8 @@ class NekoLibrary extends BaseLibrary<
     });
   }
 
-  public function new(config:NekoLibraryConfig) {
-    super(config, new NekoMarshal(this));
+  public function new(platform:Neko, config:NekoLibraryConfig) {
+    super(platform, config, new NekoMarshal(this));
     pushNative("_ammer_neko_tohaxecopy", 2, config.pos);
     pushNative("_ammer_neko_fromhaxecopy", 2, config.pos);
     pushNative("_ammer_neko_fromhaxeref", 1, config.pos);
@@ -326,6 +332,7 @@ DEFINE_PRIM(_ammer_init, 2);');
 @:allow(ammer.core.plat)
 class NekoMarshal extends BaseMarshal<
   NekoMarshal,
+  Neko,
   NekoConfig,
   NekoLibraryConfig,
   NekoLibrary,

--- a/src/ammer/core/plat/Neko.hx
+++ b/src/ammer/core/plat/Neko.hx
@@ -409,16 +409,15 @@ alloc_field($l1, _ammer_haxe_field_low, alloc_int32($l2 & 0xFFFFFFFF));',
   public function uint64():NekoTypeMarshal return MARSHAL_UINT64;
   public function int64():NekoTypeMarshal return MARSHAL_INT64;
 
-  // static final MARSHAL_FLOAT32 = baseExtend(BaseMarshal.baseFloat32(), {
-  //   l1l2: (l1, l2) -> '$l2 = val_float($l1);',
-  //   l2l1: (l2, l1) -> '$l1 = alloc_float($l2);',
-  // });
-  static final MARSHAL_FLOAT64 = baseExtend(BaseMarshal.baseFloat64(), {
-    //l1l2: (l1, l2) -> '$l2 = val_float($l1);',
+  static final MARSHAL_FLOAT32 = baseExtend(BaseMarshal.baseFloat64As32(), {
     l1l2: (l1, l2) -> '$l2 = val_number($l1);',
     l2l1: (l2, l1) -> '$l1 = alloc_float($l2);',
   });
-  public function float32():NekoTypeMarshal return throw "!";
+  static final MARSHAL_FLOAT64 = baseExtend(BaseMarshal.baseFloat64(), {
+    l1l2: (l1, l2) -> '$l2 = val_number($l1);',
+    l2l1: (l2, l1) -> '$l1 = alloc_float($l2);',
+  });
+  public function float32():NekoTypeMarshal return MARSHAL_FLOAT32;
   public function float64():NekoTypeMarshal return MARSHAL_FLOAT64;
 
   static final MARSHAL_STRING = baseExtend(BaseMarshal.baseString(), {

--- a/src/ammer/core/plat/Nodejs.hx
+++ b/src/ammer/core/plat/Nodejs.hx
@@ -551,15 +551,15 @@ class NodejsMarshal extends BaseMarshal<
   public function uint64():NodejsTypeMarshal return MARSHAL_UINT64;
   public function int64():NodejsTypeMarshal return MARSHAL_INT64;
 
-  // static final MARSHAL_FLOAT32 = baseExtend(BaseMarshal.baseFloat32(), {
-  //   l1l2: (l1, l2) -> 'NAPI_CALL_I(napi_get_value_double(_nodejs_env, $l1, &$l2));',
-  //   l2l1: (l2, l1) -> 'NAPI_CALL_I(napi_create_double(_nodejs_env, $l2, &$l1));',
-  // });
+  static final MARSHAL_FLOAT32 = baseExtend(BaseMarshal.baseFloat64As32(), {
+    l1l2: (l1, l2) -> 'NAPI_CALL_I(napi_get_value_double(_nodejs_env, $l1, &$l2));',
+    l2l1: (l2, l1) -> 'NAPI_CALL_I(napi_create_double(_nodejs_env, $l2, &$l1));',
+  });
   static final MARSHAL_FLOAT64 = baseExtend(BaseMarshal.baseFloat64(), {
     l1l2: (l1, l2) -> 'NAPI_CALL_I(napi_get_value_double(_nodejs_env, $l1, &$l2));',
     l2l1: (l2, l1) -> 'NAPI_CALL_I(napi_create_double(_nodejs_env, $l2, &$l1));',
   });
-  public function float32():NodejsTypeMarshal throw "!";
+  public function float32():NodejsTypeMarshal return MARSHAL_FLOAT32;
   public function float64():NodejsTypeMarshal return MARSHAL_FLOAT64;
 
   static final MARSHAL_STRING = baseExtend(BaseMarshal.baseString(), {

--- a/src/ammer/core/plat/Nodejs.hx
+++ b/src/ammer/core/plat/Nodejs.hx
@@ -290,16 +290,16 @@ static napi_value _ammer_nodejs_fromhaxeref(napi_env _nodejs_env, napi_callback_
 NAPI_MODULE_INIT() {
   napi_property_descriptor _init_wrap[] = {
 ').addBuf(lbInit).ail('
-    {"_ammer_nodejs_tohaxecopy", NULL, _ammer_nodejs_tohaxecopy, NULL, NULL, NULL, 0, NULL},
-    {"_ammer_nodejs_fromhaxecopy", NULL, _ammer_nodejs_fromhaxecopy, NULL, NULL, NULL, 0, NULL},
-    {"_ammer_nodejs_tohaxeref", NULL, _ammer_nodejs_tohaxeref, NULL, NULL, NULL, 0, NULL},
-    {"_ammer_nodejs_fromhaxeref", NULL, _ammer_nodejs_fromhaxeref, NULL, NULL, NULL, 0, NULL},
+    {"_ammer_nodejs_tohaxecopy", NULL, _ammer_nodejs_tohaxecopy, NULL, NULL, NULL, napi_default, NULL},
+    {"_ammer_nodejs_fromhaxecopy", NULL, _ammer_nodejs_fromhaxecopy, NULL, NULL, NULL, napi_default, NULL},
+    {"_ammer_nodejs_tohaxeref", NULL, _ammer_nodejs_tohaxeref, NULL, NULL, NULL, napi_default, NULL},
+    {"_ammer_nodejs_fromhaxeref", NULL, _ammer_nodejs_fromhaxeref, NULL, NULL, NULL, napi_default, NULL},
 
-    {"_ammer_ref_create", NULL, _ammer_ref_create, NULL, NULL, NULL, 0, NULL},
-    {"_ammer_ref_delete", NULL, _ammer_ref_delete, NULL, NULL, NULL, 0, NULL},
-    {"_ammer_ref_getcount", NULL, _ammer_ref_getcount, NULL, NULL, NULL, 0, NULL},
-    {"_ammer_ref_setcount", NULL, _ammer_ref_setcount, NULL, NULL, NULL, 0, NULL},
-    {"_ammer_ref_getvalue", NULL, _ammer_ref_getvalue, NULL, NULL, NULL, 0, NULL},
+    {"_ammer_ref_create", NULL, _ammer_ref_create, NULL, NULL, NULL, napi_default, NULL},
+    {"_ammer_ref_delete", NULL, _ammer_ref_delete, NULL, NULL, NULL, napi_default, NULL},
+    {"_ammer_ref_getcount", NULL, _ammer_ref_getcount, NULL, NULL, NULL, napi_default, NULL},
+    {"_ammer_ref_setcount", NULL, _ammer_ref_setcount, NULL, NULL, NULL, napi_default, NULL},
+    {"_ammer_ref_getvalue", NULL, _ammer_ref_getvalue, NULL, NULL, NULL, napi_default, NULL},
   };
   if (napi_define_properties(env, exports, ${exportCount + nativeCount}, _init_wrap) != napi_ok) return NULL;
   _ammer_nodejs_env = env;
@@ -342,7 +342,7 @@ NAPI_MODULE_INIT() {
         .ail("#undef NAPI_CALL_I")
       .d()
       .ail("}");
-    lbInit.ail('{"${name}", NULL, ${name}, NULL, NULL, NULL, 0, NULL},');
+    lbInit.ail('{"${name}", NULL, ${name}, NULL, NULL, NULL, napi_default, NULL},');
     exportCount++;
     tdef.fields.push({
       pos: options.pos,

--- a/src/ammer/core/plat/Nodejs.hx
+++ b/src/ammer/core/plat/Nodejs.hx
@@ -2,12 +2,6 @@ package ammer.core.plat;
 
 #if macro
 
-import haxe.macro.Context;
-import haxe.macro.Expr;
-import ammer.core.utils.*;
-
-using Lambda;
-
 @:structInit
 class NodejsConfig extends BaseConfig {
   public var nodeGypBinary:String = "node-gyp";

--- a/src/ammer/core/plat/Nodejs.hx
+++ b/src/ammer/core/plat/Nodejs.hx
@@ -32,7 +32,7 @@ class Nodejs extends Base<
   public function finalise():BuildProgram {
     var ops:Array<BuildOp> = [];
     for (lib in libraries) {
-      var ext = lib.config.abi.extension();
+      var ext = lib.config.language.extension();
       ops.push(BOAlways(File('${config.buildPath}/${lib.config.name}'), EnsureDirectory));
       ops.push(BOAlways(File(config.outputPath), EnsureDirectory));
       ops.push(BOAlways(

--- a/src/ammer/core/plat/Nodejs.hx
+++ b/src/ammer/core/plat/Nodejs.hx
@@ -628,20 +628,21 @@ NAPI_CALL_I(napi_wrap(_nodejs_env, $l1, $l2, NULL, NULL, NULL));',
     };
   }
 
-  function opaqueInternal(name:String):MarshalOpaque<NodejsTypeMarshal> return {
-    type: baseExtend(BaseMarshal.baseOpaquePtrInternal(name), {
+  function opaqueInternal(name:String):NodejsTypeMarshal return baseExtend(BaseMarshal.baseOpaqueInternal(name), {
+    haxeType: (macro : Dynamic),
+    l1l2: (l1, l2) -> 'NAPI_CALL_I(napi_unwrap(_nodejs_env, $l1, (void**)&$l2));',
+    l2l1: (l2, l1) -> 'NAPI_CALL_I(napi_create_object(_nodejs_env, &$l1));
+NAPI_CALL_I(napi_wrap(_nodejs_env, $l1, $l2, NULL, NULL, NULL));',
+  });
+
+  function structPtrDerefInternal(name:String):NodejsTypeMarshal {
+    return baseExtend(BaseMarshal.baseStructPtrDerefInternal(name), {
       haxeType: (macro : Dynamic),
       l1l2: (l1, l2) -> 'NAPI_CALL_I(napi_unwrap(_nodejs_env, $l1, (void**)&$l2));',
       l2l1: (l2, l1) -> 'NAPI_CALL_I(napi_create_object(_nodejs_env, &$l1));
 NAPI_CALL_I(napi_wrap(_nodejs_env, $l1, $l2, NULL, NULL, NULL));',
-    }),
-    typeDeref: baseExtend(BaseMarshal.baseOpaqueDirectInternal(name), {
-      haxeType: (macro : Dynamic),
-      l1l2: (l1, l2) -> 'NAPI_CALL_I(napi_unwrap(_nodejs_env, $l1, (void**)&$l2));',
-      l2l1: (l2, l1) -> 'NAPI_CALL_I(napi_create_object(_nodejs_env, &$l1));
-NAPI_CALL_I(napi_wrap(_nodejs_env, $l1, $l2, NULL, NULL, NULL));',
-    }),
-  };
+    });
+  }
 
   function arrayPtrInternalType(element:NodejsTypeMarshal):NodejsTypeMarshal return baseExtend(BaseMarshal.baseArrayPtrInternal(element), {
     haxeType: (macro : Dynamic),

--- a/src/ammer/core/plat/Nodejs.hx
+++ b/src/ammer/core/plat/Nodejs.hx
@@ -44,7 +44,7 @@ class Nodejs extends Base<
   "include_dirs": [${lib.config.includePaths.map(p -> '"$p"').join(",")}],
   "link_settings": {
     "library_dirs": [${lib.config.libraryPaths.map(p -> '"$p"').join(",")}],
-    "libraries": [${lib.config.linkNames.map(p -> '"-l$p"').join(",")}],
+    "libraries": [${lib.config.linkNames.map(p -> '"-l$p"').concat(lib.config.frameworks.map(f -> '"$f.framework"')).join(",")}],
   },
 }]}')
       ));

--- a/src/ammer/core/plat/Nodejs.hx
+++ b/src/ammer/core/plat/Nodejs.hx
@@ -650,16 +650,20 @@ NAPI_CALL_I(napi_wrap(_nodejs_env, $l1, $l2, NULL, NULL, NULL));',
 NAPI_CALL_I(napi_wrap(_nodejs_env, $l1, $l2, NULL, NULL, NULL));',
   });
 
-  function haxePtrInternal(haxeType:ComplexType):MarshalHaxe<NodejsTypeMarshal> return baseHaxePtrInternal(
-    haxeType,
-    (macro : Dynamic),
-    macro null,
-    macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_getvalue")})(handle),
-    macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_getcount")})(handle),
-    rc -> macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_setcount")})(handle, $rc),
-    value -> macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_create")})($value),
-    macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_delete")})(handle)
-  ).marshal;
+  function haxePtrInternal(haxeType:ComplexType):MarshalHaxe<NodejsTypeMarshal> {
+    var ret = baseHaxePtrInternal(
+      haxeType,
+      (macro : Dynamic),
+      macro null,
+      macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_getvalue")})(handle),
+      macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_getcount")})(handle),
+      rc -> macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_setcount")})(handle, $rc),
+      value -> macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_create")})($value),
+      macro (@:privateAccess $e{library.fieldExpr("_ammer_ref_delete")})(handle)
+    );
+    TypeUtils.defineType(ret.tdef);
+    return ret.marshal;
+  }
 
   function haxePtrInternalType(haxeType:ComplexType):NodejsTypeMarshal return baseExtend(BaseMarshal.baseHaxePtrInternalType(haxeType), {
       haxeType: (macro : Dynamic),

--- a/src/ammer/core/plat/Nodejs.hx
+++ b/src/ammer/core/plat/Nodejs.hx
@@ -19,6 +19,7 @@ typedef NodejsLibraryConfig = LibraryConfig;
 typedef NodejsTypeMarshal = BaseTypeMarshal;
 
 class Nodejs extends Base<
+  Nodejs,
   NodejsConfig,
   NodejsLibraryConfig,
   NodejsTypeMarshal,
@@ -27,6 +28,10 @@ class Nodejs extends Base<
 > {
   public function new(config:NodejsConfig) {
     super("nodejs", config);
+  }
+
+  public function createLibrary(libConfig:NodejsLibraryConfig):NodejsLibrary {
+    return new NodejsLibrary(this, libConfig);
   }
 
   public function finalise():BuildProgram {
@@ -72,6 +77,7 @@ class Nodejs extends Base<
 
 class NodejsLibrary extends BaseLibrary<
   NodejsLibrary,
+  Nodejs,
   NodejsConfig,
   NodejsLibraryConfig,
   NodejsTypeMarshal,
@@ -91,8 +97,8 @@ class NodejsLibrary extends BaseLibrary<
     });
   }
 
-  public function new(config:NodejsLibraryConfig) {
-    super(config, new NodejsMarshal(this));
+  public function new(platform:Nodejs, config:NodejsLibraryConfig) {
+    super(platform, config, new NodejsMarshal(this));
     tdef.isExtern = true;
     tdef.meta.push({
       pos: config.pos,
@@ -139,7 +145,7 @@ static napi_value _ammer_ref_create(napi_env _nodejs_env, napi_callback_info _no
   size_t _nodejs_argc = 1;
   napi_value _nodejs_argv[1];
   NAPI_CALL(napi_get_cb_info(_nodejs_env, _nodejs_cbinfo, &_nodejs_argc, _nodejs_argv, NULL, NULL));
-  _ammer_haxe_ref* ref = ${config.mallocFunction}(sizeof(_ammer_haxe_ref));
+  _ammer_haxe_ref* ref = (_ammer_haxe_ref*)${config.mallocFunction}(sizeof(_ammer_haxe_ref));
   NAPI_CALL(napi_create_reference(_nodejs_env, _nodejs_argv[0], 1, &ref->value));
   ref->refcount = 0;
   napi_value res;
@@ -426,6 +432,7 @@ NAPI_MODULE_INIT() {
 @:allow(ammer.core.plat)
 class NodejsMarshal extends BaseMarshal<
   NodejsMarshal,
+  Nodejs,
   NodejsConfig,
   NodejsLibraryConfig,
   NodejsLibrary,

--- a/src/ammer/core/plat/None.hx
+++ b/src/ammer/core/plat/None.hx
@@ -1,0 +1,196 @@
+package ammer.core.plat;
+
+#if macro
+
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import ammer.core.utils.*;
+
+using Lambda;
+
+typedef NoneConfig = BaseConfig;
+
+typedef NoneLibraryConfig = LibraryConfig;
+
+typedef NoneTypeMarshal = BaseTypeMarshal;
+
+class None extends Base<
+  None,
+  NoneConfig,
+  NoneLibraryConfig,
+  NoneTypeMarshal,
+  NoneLibrary,
+  NoneMarshal
+> {
+  public function new(config:NoneConfig) {
+    super("none", config);
+  }
+
+  public function createLibrary(libConfig:NoneLibraryConfig):NoneLibrary {
+    return new NoneLibrary(this, libConfig);
+  }
+
+  public function finalise():BuildProgram {
+    return new BuildProgram([]);
+  }
+}
+
+@:allow(ammer.core.plat)
+class NoneLibrary extends BaseLibrary<
+  NoneLibrary,
+  None,
+  NoneConfig,
+  NoneLibraryConfig,
+  NoneTypeMarshal,
+  NoneMarshal
+> {
+  var lbHeader = new LineBuf();
+
+  public function new(platform:None, config:NoneLibraryConfig) {
+    super(platform, config, new NoneMarshal(this));
+  }
+
+  public function addNamedFunction(
+    name:String,
+    ret:NoneTypeMarshal,
+    args:Array<NoneTypeMarshal>,
+    code:String,
+    options:FunctionOptions
+  ):Expr {
+    return macro throw 0;
+  }
+
+  public function closureCall(
+    fn:String,
+    clType:MarshalClosure<NoneTypeMarshal>,
+    outputExpr:String,
+    args:Array<String>
+  ):String {
+    return "#invalid#";
+  }
+
+  public function addCallback(
+    ret:NoneTypeMarshal,
+    args:Array<NoneTypeMarshal>,
+    code:String
+  ):String {
+    return "#invalid#";
+  }
+}
+
+@:allow(ammer.core.plat)
+class NoneMarshal extends BaseMarshal<
+  NoneMarshal,
+  None,
+  NoneConfig,
+  NoneLibraryConfig,
+  NoneLibrary,
+  NoneTypeMarshal
+> {
+  static final MARSHAL_VOID = BaseMarshal.baseVoid();
+  public function void():NoneTypeMarshal return MARSHAL_VOID;
+
+  static final MARSHAL_BOOL = BaseMarshal.baseBool();
+  public function bool():NoneTypeMarshal return MARSHAL_BOOL;
+
+  static final MARSHAL_UINT8  = BaseMarshal.baseUint8();
+  static final MARSHAL_INT8   = BaseMarshal.baseInt8();
+  static final MARSHAL_UINT16 = BaseMarshal.baseUint16();
+  static final MARSHAL_INT16  = BaseMarshal.baseInt16();
+  static final MARSHAL_UINT32 = BaseMarshal.baseUint32();
+  static final MARSHAL_INT32  = BaseMarshal.baseInt32();
+  public function uint8():NoneTypeMarshal return MARSHAL_UINT8;
+  public function int8():NoneTypeMarshal return MARSHAL_INT8;
+  public function uint16():NoneTypeMarshal return MARSHAL_UINT16;
+  public function int16():NoneTypeMarshal return MARSHAL_INT16;
+  public function uint32():NoneTypeMarshal return MARSHAL_UINT32;
+  public function int32():NoneTypeMarshal return MARSHAL_INT32;
+
+  static final MARSHAL_UINT64 = BaseMarshal.baseUint64();
+  static final MARSHAL_INT64  = BaseMarshal.baseInt64();
+  public function uint64():NoneTypeMarshal return MARSHAL_UINT64;
+  public function int64():NoneTypeMarshal return MARSHAL_INT64;
+
+  static final MARSHAL_FLOAT32 = BaseMarshal.baseFloat32();
+  static final MARSHAL_FLOAT64 = BaseMarshal.baseFloat64();
+  public function float32():NoneTypeMarshal return MARSHAL_FLOAT32;
+  public function float64():NoneTypeMarshal return MARSHAL_FLOAT64;
+
+  static final MARSHAL_STRING = BaseMarshal.baseString();
+  public function string():NoneTypeMarshal return MARSHAL_STRING;
+
+  static final MARSHAL_BYTES = BaseMarshal.baseBytesInternal();
+  function bytesInternalType():NoneTypeMarshal return MARSHAL_BYTES;
+  function bytesInternalOps(
+    alloc:(size:Expr)->Expr,
+    blit:(source:Expr, srcpos:Expr, dest:Expr, dstpost:Expr, size:Expr)->Expr
+  ):{
+    toHaxeCopy:(self:Expr, size:Expr)->Expr,
+    fromHaxeCopy:(bytes:Expr)->Expr,
+    toHaxeRef:Null<(self:Expr, size:Expr)->Expr>,
+    fromHaxeRef:Null<(bytes:Expr)->Expr>,
+  } {
+    return {
+      toHaxeCopy: (self, size) -> macro throw 0,
+      fromHaxeCopy: (bytes) -> macro throw 0,
+
+      toHaxeRef: (self, size) -> macro throw 0,
+      fromHaxeRef: (bytes) -> macro throw 0,
+    };
+  }
+
+  function opaqueInternal(name:String):MarshalOpaque<NoneTypeMarshal> {
+    return {
+      type: BaseMarshal.baseOpaquePtrInternal(name),
+      typeDeref: BaseMarshal.baseOpaqueDirectInternal(name),
+    };
+  }
+
+  function arrayPtrInternalType(element:NoneTypeMarshal):NoneTypeMarshal {
+    return BaseMarshal.baseArrayPtrInternal(element);
+  }
+
+  override function arrayPtrInternalOps(
+    type:NoneTypeMarshal,
+    element:NoneTypeMarshal,
+    alloc:(size:Expr)->Expr
+    // blit:(source:Expr, srcpos:Expr, dest:Expr, dstpost:Expr, size:Expr)->Expr
+  ):{
+    vectorType:Null<ComplexType>,
+    toHaxeCopy:Null<(self:Expr, size:Expr)->Expr>,
+    fromHaxeCopy:Null<(array:Expr)->Expr>,
+    toHaxeRef:Null<(self:Expr, size:Expr)->Expr>,
+    fromHaxeRef:Null<(array:Expr)->Expr>,
+  } {
+    return {
+      vectorType: (macro : Void),
+      toHaxeCopy: (self, size) -> macro throw 0,
+      fromHaxeCopy: (vector) -> macro throw 0,
+      toHaxeRef: (self, size) -> macro throw 0,
+      fromHaxeRef: (vector) -> macro throw 0,
+    };
+  }
+
+  function haxePtrInternal(haxeType:ComplexType):MarshalHaxe<NoneTypeMarshal> {
+    var res = baseHaxePtrInternal(
+      haxeType,
+      (macro : Int),
+      macro null,
+      macro throw 0,
+      macro throw 0,
+      rc -> macro throw 0,
+      value -> macro throw 0,
+      macro throw 0
+    );
+    TypeUtils.defineType(res.tdef);
+    return res.marshal;
+  }
+
+  function haxePtrInternalType(haxeType:ComplexType):NoneTypeMarshal return BaseMarshal.baseHaxePtrInternalType(haxeType);
+
+  public function new(library:NoneLibrary) {
+    super(library);
+  }
+}
+
+#end

--- a/src/ammer/core/plat/None.hx
+++ b/src/ammer/core/plat/None.hx
@@ -2,12 +2,6 @@ package ammer.core.plat;
 
 #if macro
 
-import haxe.macro.Context;
-import haxe.macro.Expr;
-import ammer.core.utils.*;
-
-using Lambda;
-
 typedef NoneConfig = BaseConfig;
 
 typedef NoneLibraryConfig = LibraryConfig;

--- a/src/ammer/core/plat/None.hx
+++ b/src/ammer/core/plat/None.hx
@@ -139,11 +139,12 @@ class NoneMarshal extends BaseMarshal<
     };
   }
 
-  function opaqueInternal(name:String):MarshalOpaque<NoneTypeMarshal> {
-    return {
-      type: BaseMarshal.baseOpaquePtrInternal(name),
-      typeDeref: BaseMarshal.baseOpaqueDirectInternal(name),
-    };
+  function opaqueInternal(name:String):NoneTypeMarshal {
+    return BaseMarshal.baseOpaqueInternal(name);
+  }
+
+  function structPtrDerefInternal(name:String):NoneTypeMarshal {
+    return BaseMarshal.baseStructPtrDerefInternal(name);
   }
 
   function arrayPtrInternalType(element:NoneTypeMarshal):NoneTypeMarshal {

--- a/src/ammer/core/plat/Python.hx
+++ b/src/ammer/core/plat/Python.hx
@@ -510,7 +510,7 @@ class PythonMarshal extends BaseMarshal<
 
   function haxePtrInternal(haxeType:ComplexType):MarshalHaxe<PythonTypeMarshal> {
     var tdefExternExpr = library.tdefExternExpr;
-    return baseHaxePtrInternal(
+    var ret = baseHaxePtrInternal(
       haxeType,
       (macro : Int),
       macro 0,
@@ -521,7 +521,9 @@ class PythonMarshal extends BaseMarshal<
       macro (@:privateAccess $tdefExternExpr._ammer_ref_delete)(handle),
       null,
       handle -> macro $handle == null || $handle == 0
-    ).marshal;
+    );
+    TypeUtils.defineType(ret.tdef);
+    return ret.marshal;
   }
 
   function haxePtrInternalType(haxeType:ComplexType):PythonTypeMarshal return baseExtend(BaseMarshal.baseHaxePtrInternalType(haxeType), {

--- a/src/ammer/core/plat/Python.hx
+++ b/src/ammer/core/plat/Python.hx
@@ -146,7 +146,7 @@ static PyObject* _ammer_python_frombytesunref(PyObject *_python_self, PyObject *
 
 typedef struct { PyObject* value; int32_t refcount; } _ammer_haxe_ref;
 static PyObject* _ammer_ref_create(PyObject *_python_self, PyObject *_python_args) {
-  _ammer_haxe_ref* ref = ${config.mallocFunction}(sizeof(_ammer_haxe_ref));
+  _ammer_haxe_ref* ref = (_ammer_haxe_ref*)${config.mallocFunction}(sizeof(_ammer_haxe_ref));
   ref->value = PyTuple_GetItem(_python_args, 0);
   ref->refcount = 0;
   Py_XINCREF(ref->value);

--- a/src/ammer/core/plat/Python.hx
+++ b/src/ammer/core/plat/Python.hx
@@ -39,7 +39,7 @@ class Python extends Base<
     return baseDynamicLinkProgram({
       includePaths: config.pythonIncludePaths,
       libraryPaths: config.pythonLibraryPaths,
-      defines: ["NDEBUG", "MAJOR_VERSION=1", "MINOR_VERSION=0"],
+      defines: lib -> ["NDEBUG", "MAJOR_VERSION=1", "MINOR_VERSION=0"].concat(lib.config.defines),
       linkNames: ['python3${BuildProgram.useMSVC ? "" : "."}${config.pythonVersionMinor}'],
       // .so is intentional on macOS
       outputPath: lib -> '${config.outputPath}/${lib.config.name}.${BuildProgram.useMSVC ? "pyd" : "so"}',

--- a/src/ammer/core/plat/Python.hx
+++ b/src/ammer/core/plat/Python.hx
@@ -489,18 +489,19 @@ class PythonMarshal extends BaseMarshal<
     };
   }
 
-  function opaqueInternal(name:String):MarshalOpaque<PythonTypeMarshal> return {
-    type: baseExtend(BaseMarshal.baseOpaquePtrInternal(name), {
+  function opaqueInternal(name:String):PythonTypeMarshal return baseExtend(BaseMarshal.baseOpaqueInternal(name), {
+    haxeType: (macro : Int),
+    l1l2: (l1, l2) -> '$l2 = ($name)(PyLong_AsUnsignedLongLong($l1));',
+    l2l1: (l2, l1) -> '$l1 = PyLong_FromUnsignedLongLong((uint64_t)$l2);',
+  });
+
+  function structPtrDerefInternal(name:String):PythonTypeMarshal {
+    return baseExtend(BaseMarshal.baseStructPtrDerefInternal(name), {
       haxeType: (macro : Int),
       l1l2: (l1, l2) -> '$l2 = ($name*)(PyLong_AsUnsignedLongLong($l1));',
       l2l1: (l2, l1) -> '$l1 = PyLong_FromUnsignedLongLong((uint64_t)$l2);',
-    }),
-    typeDeref: baseExtend(BaseMarshal.baseOpaqueDirectInternal(name), {
-      haxeType: (macro : Int),
-      l1l2: (l1, l2) -> '$l2 = ($name*)(PyLong_AsUnsignedLongLong($l1));',
-      l2l1: (l2, l1) -> '$l1 = PyLong_FromUnsignedLongLong((uint64_t)$l2);',
-    }),
-  };
+    });
+  }
 
   function arrayPtrInternalType(element:PythonTypeMarshal):PythonTypeMarshal return baseExtend(BaseMarshal.baseArrayPtrInternal(element), {
     haxeType: (macro : Int),

--- a/src/ammer/core/plat/Python.hx
+++ b/src/ammer/core/plat/Python.hx
@@ -2,12 +2,6 @@ package ammer.core.plat;
 
 #if macro
 
-import haxe.macro.Context;
-import haxe.macro.Expr;
-import ammer.core.utils.*;
-
-using Lambda;
-
 @:structInit
 class PythonConfig extends BaseConfig {
   public var pythonVersionMinor = 8; // 3.8

--- a/src/ammer/core/plat/Python.hx
+++ b/src/ammer/core/plat/Python.hx
@@ -20,6 +20,7 @@ typedef PythonLibraryConfig = LibraryConfig;
 typedef PythonTypeMarshal = BaseTypeMarshal;
 
 class Python extends Base<
+  Python,
   PythonConfig,
   PythonLibraryConfig,
   PythonTypeMarshal,
@@ -28,6 +29,10 @@ class Python extends Base<
 > {
   public function new(config:PythonConfig) {
     super("python", config);
+  }
+
+  public function createLibrary(libConfig:PythonLibraryConfig):PythonLibrary {
+    return new PythonLibrary(this, libConfig);
   }
 
   public function finalise():BuildProgram {
@@ -45,6 +50,7 @@ class Python extends Base<
 @:allow(ammer.core.plat)
 class PythonLibrary extends BaseLibrary<
   PythonLibrary,
+  Python,
   PythonConfig,
   PythonLibraryConfig,
   PythonTypeMarshal,
@@ -63,8 +69,8 @@ class PythonLibrary extends BaseLibrary<
     });
   }
 
-  public function new(config:PythonLibraryConfig) {
-    super(config, new PythonMarshal(this));
+  public function new(platform:Python, config:PythonLibraryConfig) {
+    super(platform, config, new PythonMarshal(this));
     tdefExtern = typeDefCreate();
     tdefExtern.name += "_Native";
     tdefExtern.isExtern = true;
@@ -328,6 +334,7 @@ PyMODINIT_FUNC PyInit_${config.name}(void) {
 @:allow(ammer.core.plat)
 class PythonMarshal extends BaseMarshal<
   PythonMarshal,
+  Python,
   PythonConfig,
   PythonLibraryConfig,
   PythonLibrary,

--- a/src/ammer/core/plat/Python.hx
+++ b/src/ammer/core/plat/Python.hx
@@ -424,15 +424,15 @@ class PythonMarshal extends BaseMarshal<
   public function uint64():PythonTypeMarshal return MARSHAL_UINT64;
   public function int64():PythonTypeMarshal return MARSHAL_INT64;
 
-  // static final MARSHAL_FLOAT32 = baseExtend(BaseMarshal.baseFloat32(), {
-  //   l1l2: (l1, l2) -> '$l2 = PyFloat_AsDouble($l1);',
-  //   l2l1: (l2, l1) -> '$l1 = PyFloat_FromDouble($l2);',
-  // });
+  static final MARSHAL_FLOAT32 = baseExtend(BaseMarshal.baseFloat64As32(), {
+    l1l2: (l1, l2) -> '$l2 = PyFloat_AsDouble($l1);',
+    l2l1: (l2, l1) -> '$l1 = PyFloat_FromDouble($l2);',
+  });
   static final MARSHAL_FLOAT64 = baseExtend(BaseMarshal.baseFloat64(), {
     l1l2: (l1, l2) -> '$l2 = PyFloat_AsDouble($l1);',
     l2l1: (l2, l1) -> '$l1 = PyFloat_FromDouble($l2);',
   });
-  public function float32():PythonTypeMarshal return throw "!";
+  public function float32():PythonTypeMarshal return MARSHAL_FLOAT32;
   public function float64():PythonTypeMarshal return MARSHAL_FLOAT64;
 
   static final MARSHAL_STRING = baseExtend(BaseMarshal.baseString(), {

--- a/src/ammer/core/plat/import.hx
+++ b/src/ammer/core/plat/import.hx
@@ -1,0 +1,10 @@
+#if macro
+
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import ammer.core.utils.*;
+
+using Lambda;
+using StringTools;
+
+#end

--- a/src/ammer/core/utils/TypeUtils.hx
+++ b/src/ammer/core/utils/TypeUtils.hx
@@ -1,5 +1,6 @@
 package ammer.core.utils;
 
+import haxe.macro.Context;
 import haxe.macro.Expr;
 
 class TypeUtils {
@@ -37,5 +38,12 @@ class TypeUtils {
       });
       case _: throw 0;
     });
+  }
+
+  public static var definedTypes:Array<TypeDefinition> = [];
+
+  public static function defineType(tdef:TypeDefinition):Void {
+    definedTypes.push(tdef);
+    Context.defineType(tdef);
   }
 }

--- a/test/build/build-eval.hxml
+++ b/test/build/build-eval.hxml
@@ -1,0 +1,3 @@
+-D AMMER_TEST_EVAL
+build/build-common.hxml
+--interp

--- a/test/src/LibraryConfig.hx
+++ b/test/src/LibraryConfig.hx
@@ -3,6 +3,7 @@
 typedef LibraryConfig =
   #if AMMER_TEST_CPP_STATIC                   ammer.core.plat.Cpp.CppLibraryConfig
   #elseif AMMER_TEST_CS                       ammer.core.plat.Cs.CsLibraryConfig
+  #elseif AMMER_TEST_EVAL                     ammer.core.plat.Eval.EvalLibraryConfig
   #elseif (AMMER_TEST_HL || AMMER_TEST_HLC)   ammer.core.plat.Hashlink.HashlinkLibraryConfig
   #elseif (AMMER_TEST_JAVA || AMMER_TEST_JVM) ammer.core.plat.Java.JavaLibraryConfig
   #elseif AMMER_TEST_LUA                      ammer.core.plat.Lua.LuaLibraryConfig

--- a/test/src/PlatformConfig.hx
+++ b/test/src/PlatformConfig.hx
@@ -3,6 +3,7 @@
 typedef PlatformConfig =
   #if AMMER_TEST_CPP_STATIC                   ammer.core.plat.Cpp.CppConfig
   #elseif AMMER_TEST_CS                       ammer.core.plat.Cs.CsConfig
+  #elseif AMMER_TEST_EVAL                     ammer.core.plat.Eval.EvalConfig
   #elseif (AMMER_TEST_HL || AMMER_TEST_HLC)   ammer.core.plat.Hashlink.HashlinkConfig
   #elseif (AMMER_TEST_JAVA || AMMER_TEST_JVM) ammer.core.plat.Java.JavaConfig
   #elseif AMMER_TEST_LUA                      ammer.core.plat.Lua.LuaConfig

--- a/test/src/TestHarness.macro.hx
+++ b/test/src/TestHarness.macro.hx
@@ -6,6 +6,7 @@ class TestHarness {
     var platformId =
       #if AMMER_TEST_CPP_STATIC "cpp-static" #end
       #if AMMER_TEST_CS "cs" #end
+      #if AMMER_TEST_EVAL "eval" #end
       #if AMMER_TEST_HL "hl" #end
       #if AMMER_TEST_HLC "hlc" #end
       #if AMMER_TEST_JAVA "java" #end
@@ -17,6 +18,7 @@ class TestHarness {
       ;
     var gcMajor = macro
       #if AMMER_TEST_CPP_STATIC cpp.vm.Gc.run(true)
+      #elseif AMMER_TEST_EVAL eval.vm.Gc.major()
       #elseif (AMMER_TEST_HL || AMMER_TEST_HLC) hl.Gc.major()
       #elseif (AMMER_TEST_JAVA || AMMER_TEST_JVM) java.vm.Gc.run(true)
       #elseif AMMER_TEST_LUA lua.Lua.collectgarbage(Collect)
@@ -44,6 +46,9 @@ class TestHarness {
     var platform = ammer.core.Platform.createCurrentPlatform(({
       buildPath: 'bin/$platformId/ammer_build',
       outputPath: 'bin/$platformId',
+      #if AMMER_TEST_EVAL
+        haxeRepoPath: paths("eval.haxerepopath")[0],
+      #end
       #if AMMER_TEST_HLC
         hlc: true,
       #end

--- a/test/src/TestHarness.macro.hx
+++ b/test/src/TestHarness.macro.hx
@@ -93,7 +93,6 @@ class TestHarness {
 
     var testExprs:Array<Expr> = [];
     for (ctor in ([
-      test.TestHaxe.new,
       #if !AMMER_TEST_CS
         test.TestArrays.new,
       #end
@@ -101,6 +100,7 @@ class TestHarness {
       test.TestBytes.new,
       test.TestCallbacks.new,
       test.TestFloats.new,
+      test.TestHaxe.new,
       test.TestIntegers.new,
       test.TestStrings.new,
       test.TestStructs.new,

--- a/test/src/test/TestArrays.hx
+++ b/test/src/test/TestArrays.hx
@@ -22,7 +22,7 @@ class TestArrays extends TestBase {
       {m: marshal.int64(),   l: macro haxe.Int64.make(0xF0001324, 0xF0432100)},
       {m: marshal.uint64(),  l: macro haxe.Int64.make(0xF0001324, 0xF0432100)},
       #end
-      #if !(AMMER_TEST_LUA || AMMER_TEST_NEKO || AMMER_TEST_NODEJS || AMMER_TEST_PYTHON)
+      #if !(AMMER_TEST_EVAL || AMMER_TEST_LUA || AMMER_TEST_NEKO || AMMER_TEST_NODEJS || AMMER_TEST_PYTHON)
       {m: marshal.float32(), l: macro 7                                      },
       #end
       {m: marshal.float64(), l: macro 7                                      },

--- a/test/src/test/TestArrays.hx
+++ b/test/src/test/TestArrays.hx
@@ -22,9 +22,7 @@ class TestArrays extends TestBase {
       {m: marshal.int64(),   l: macro haxe.Int64.make(0xF0001324, 0xF0432100)},
       {m: marshal.uint64(),  l: macro haxe.Int64.make(0xF0001324, 0xF0432100)},
       #end
-      #if !(AMMER_TEST_EVAL || AMMER_TEST_LUA || AMMER_TEST_NEKO || AMMER_TEST_NODEJS || AMMER_TEST_PYTHON)
       {m: marshal.float32(), l: macro 7                                      },
-      #end
       {m: marshal.float64(), l: macro 7                                      },
     ]) {
       var type = marshal.arrayPtr(kind.m);

--- a/test/src/test/TestFloats.hx
+++ b/test/src/test/TestFloats.hx
@@ -6,16 +6,14 @@ class TestFloats extends TestBase {
   public function new() {
     super("TestFloats");
     for (kind in [
-      #if !(AMMER_TEST_EVAL || AMMER_TEST_LUA || AMMER_TEST_NEKO || AMMER_TEST_NODEJS || AMMER_TEST_PYTHON)
       {m: marshal.float32() },
-      #end
       {m: marshal.float64() },
       // {m: marshal.float128()},
     ]) {
       var f = lib.addFunction(kind.m, [kind.m], '_return = _arg0 * 2.0;');
       // TODO: epsilon?
-      assertEq(macro $f(3.21),  macro 6.42 , kind.m.haxeType);
-      assertEq(macro $f(-3.21), macro -6.42, kind.m.haxeType);
+      assertEq(macro $f(3.5),  macro 7.0,  kind.m.haxeType);
+      assertEq(macro $f(-3.5), macro -7.0, kind.m.haxeType);
     }
   }
 }

--- a/test/src/test/TestFloats.hx
+++ b/test/src/test/TestFloats.hx
@@ -6,7 +6,7 @@ class TestFloats extends TestBase {
   public function new() {
     super("TestFloats");
     for (kind in [
-      #if !(AMMER_TEST_LUA || AMMER_TEST_NEKO || AMMER_TEST_NODEJS || AMMER_TEST_PYTHON)
+      #if !(AMMER_TEST_EVAL || AMMER_TEST_LUA || AMMER_TEST_NEKO || AMMER_TEST_NODEJS || AMMER_TEST_PYTHON)
       {m: marshal.float32() },
       #end
       {m: marshal.float64() },

--- a/test/src/test/TestStructs.hx
+++ b/test/src/test/TestStructs.hx
@@ -37,9 +37,7 @@ class TestStructs extends TestBase {
       {m: marshal.int64(),   l: macro haxe.Int64.make(0xF0001324, 0xF0432100)},
       {m: marshal.uint64(),  l: macro haxe.Int64.make(0xF0001324, 0xF0432100)},
       #end
-      #if !(AMMER_TEST_EVAL || AMMER_TEST_LUA || AMMER_TEST_NEKO || AMMER_TEST_NODEJS || AMMER_TEST_PYTHON)
       {m: marshal.float32(), l: macro 7                                      },
-      #end
       {m: marshal.float64(), l: macro 7                                      },
     ]) {
       var type = marshal.boxPtr(kind.m);

--- a/test/src/test/TestStructs.hx
+++ b/test/src/test/TestStructs.hx
@@ -37,7 +37,7 @@ class TestStructs extends TestBase {
       {m: marshal.int64(),   l: macro haxe.Int64.make(0xF0001324, 0xF0432100)},
       {m: marshal.uint64(),  l: macro haxe.Int64.make(0xF0001324, 0xF0432100)},
       #end
-      #if !(AMMER_TEST_LUA || AMMER_TEST_NEKO || AMMER_TEST_NODEJS || AMMER_TEST_PYTHON)
+      #if !(AMMER_TEST_EVAL || AMMER_TEST_LUA || AMMER_TEST_NEKO || AMMER_TEST_NODEJS || AMMER_TEST_PYTHON)
       {m: marshal.float32(), l: macro 7                                      },
       #end
       {m: marshal.float64(), l: macro 7                                      },

--- a/test/test-all.sh
+++ b/test/test-all.sh
@@ -3,6 +3,7 @@
 true \
     && echo "cpp-static ... " && test/test-cpp-static.sh \
     && echo "cs ... " && test/test-cs.sh \
+    && echo "eval ... " && haxe build/build-eval.hxml \
     && echo "hl ... " && test/test-hl.sh \
     && echo "hlc ... " && test/test-hlc.sh \
     && echo "java ... " && test/test-java.sh \

--- a/test/test/test-hlc-macos.sh
+++ b/test/test/test-hlc-macos.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
-DYLD_LIBRARY_PATH=bin/hlc bin/hlc/main
+cd bin/hlc
+./main

--- a/test/test/test-hlc-windows.sh
+++ b/test/test/test-hlc-windows.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 cd bin/hlc
-main.exe
+./main.exe


### PR DESCRIPTION
Summary of major changes:

- Added `eval` target. Currently requires a Haxe development setup, i.e. repository checked out, OCaml/`opam`/`dune` set up. Closes #2.
- Fixed #12.
- Added support for 32-bit floats on targets that don't support them natively (no `Single` type) by a lossy conversion from/to 64-bit floats.