### PR TITLE
Update `master`

### DIFF
--- a/.github/workflows/test-eval.yml
+++ b/.github/workflows/test-eval.yml
@@ -42,9 +42,9 @@ jobs:
 
     - name: Install dependencies
       env:
-        ZLIB_VERSION: 1.2.12
+        ZLIB_VERSION: 1.2.13
         MBEDTLS_VERSION: 2.25.0
-        PCRE_VERSION: 10.39
+        PCRE_VERSION: 8.44
       run: |
         cd haxe
         set -ex
@@ -55,6 +55,7 @@ jobs:
         brew update
         # brew unlink python@2
         brew bundle --file=tests/Brewfile --no-upgrade || brew link --overwrite awscli
+        brew install libunistring
         brew install cpanminus
         cpanm IPC::System::Simple
         cpanm String::ShellQuote
@@ -62,13 +63,16 @@ jobs:
         cd zlib-$ZLIB_VERSION
         ./configure
         make && make install
+        cd ..
         curl -L https://github.com/ARMmbed/mbedtls/archive/v$MBEDTLS_VERSION.tar.gz | tar xz
         cd mbedtls-$MBEDTLS_VERSION
         make && make install
-        curl -L https://github.com/PhilipHazel/pcre2/releases/download/pcre2-10.39/pcre2-$PCRE_VERSION.tar.gz | tar xz
-        cd pcre2-$PCRE_VERSION
-        ./configure --enable-utf8 --enable-pcre2-8 --enable-pcre2-16 --enable-pcre2-32 --enable-unicode-properties --enable-pcregrep-libz --enable-pcregrep-libbz2 --enable-jit
+        cd ..
+        curl -L https://downloads.sourceforge.net/project/pcre/pcre/$PCRE_VERSION/pcre-$PCRE_VERSION.tar.gz | tar xz
+        cd pcre-$PCRE_VERSION
+        ./configure --enable-utf8 --enable-pcre8 --enable-pcre16 --enable-pcre32 --enable-unicode-properties --enable-pcregrep-libz --enable-pcregrep-libbz2 --enable-jit
         make && make install
+        cd ..
 
     - name: Install OCaml libraries
       run: |

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -54,15 +54,15 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         cd ammer-core/test
-        haxe -D ammercoretest.java.includepaths="$JAVA_HOME/include;$JAVA_HOME/include/linux" build/build-java.hxml
-        haxe -D ammercoretest.java.includepaths="$JAVA_HOME/include;$JAVA_HOME/include/linux" build/build-jvm.hxml
+        haxe -D ammercoretest.java.includepaths="$JAVA_HOME/include;$JAVA_HOME/include/linux" -D ammercoretest.java.librarypaths="$JAVA_HOME/lib/server" build/build-java.hxml
+        haxe -D ammercoretest.java.includepaths="$JAVA_HOME/include;$JAVA_HOME/include/linux" -D ammercoretest.java.librarypaths="$JAVA_HOME/lib/server" build/build-jvm.hxml
 
     - name: Compile tests (macOS)
       if: matrix.os == 'macos-latest'
       run: |
         cd ammer-core/test
-        haxe -D ammercoretest.java.includepaths="$JAVA_HOME/include;$JAVA_HOME/include/darwin" build/build-java.hxml
-        haxe -D ammercoretest.java.includepaths="$JAVA_HOME/include;$JAVA_HOME/include/darwin" build/build-jvm.hxml
+        haxe -D ammercoretest.java.includepaths="$JAVA_HOME/include;$JAVA_HOME/include/darwin" -D ammercoretest.java.librarypaths="$JAVA_HOME/jre/lib/server" build/build-java.hxml
+        haxe -D ammercoretest.java.includepaths="$JAVA_HOME/include;$JAVA_HOME/include/darwin" -D ammercoretest.java.librarypaths="$JAVA_HOME/jre/lib/server" build/build-jvm.hxml
  
     - name: Compile tests (Windows)
       if: matrix.os == 'windows-latest'
@@ -71,8 +71,8 @@ jobs:
         # https://github.com/ilammy/msvc-dev-cmd#name-conflicts-with-shell-bash
         rm /usr/bin/link
         cd ammer-core/test
-        haxe -D ammercoretest.java.includepaths="$JAVA_HOME\include;$JAVA_HOME\include\win32" build/build-java.hxml
-        haxe -D ammercoretest.java.includepaths="$JAVA_HOME\include;$JAVA_HOME\include\win32" build/build-jvm.hxml
+        haxe -D ammercoretest.java.includepaths="$JAVA_HOME\include;$JAVA_HOME\include\win32" -D ammercoretest.java.librarypaths="$JAVA_HOME\jre\bin\server;$JAVA_HOME\lib" build/build-java.hxml
+        haxe -D ammercoretest.java.includepaths="$JAVA_HOME\include;$JAVA_HOME\include\win32" -D ammercoretest.java.librarypaths="$JAVA_HOME\jre\bin\server;$JAVA_HOME\lib" build/build-jvm.hxml
 
     - name: Run tests
       shell: bash

--- a/.github/workflows/test-lua.yml
+++ b/.github/workflows/test-lua.yml
@@ -63,7 +63,14 @@ jobs:
 
     - name: Install Lua and dependencies (macOS)
       if: matrix.os == 'macos-latest'
+      env:
+        PCRE_VERSION: 8.44
       run: |
+        curl -L https://downloads.sourceforge.net/project/pcre/pcre/$PCRE_VERSION/pcre-$PCRE_VERSION.tar.gz | tar xz
+        cd pcre-$PCRE_VERSION
+        ./configure --enable-utf8 --enable-pcre8 --enable-pcre16 --enable-pcre32 --enable-unicode-properties --enable-pcregrep-libz --enable-pcregrep-libbz2 --enable-jit
+        make && make install
+        cd ..
         brew install lua luarocks
         luarocks install lrexlib-pcre 2.9.1-1
         luarocks install luv 1.41.1-0

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -53,8 +53,11 @@ jobs:
     - name: Compile tests (Linux)
       if: matrix.os == 'ubuntu-latest'
       run: |
+        python3-config --cflags
+        python3-config --ldflags
+        python3-config --libs
         cd ammer-core/test
-        haxe -D ammercoretest.python.includepaths="/usr/include/python3.8;/usr/include/x86_64-linux-gnu/python3.8" -D ammercoretest.python.version=8 build/build-python.hxml
+        haxe -D ammercoretest.python.includepaths="/usr/include/python3.10" -D ammercoretest.python.librarypaths="/usr/lib/python3.10/config-3.10-x86_64-linux-gnu" -D ammercoretest.python.version=10 build/build-python.hxml
 
     - name: Compile tests (macOS)
       if: matrix.os == 'macos-latest'
@@ -63,7 +66,7 @@ jobs:
         python3-config --ldflags
         python3-config --libs
         cd ammer-core/test
-        haxe -D ammercoretest.python.includepaths=/usr/local/opt/python@3.10/Frameworks/Python.framework/Versions/3.10/include/python3.10 -D ammercoretest.python.librarypaths=/usr/local/opt/python@3.10/Frameworks/Python.framework/Versions/3.10/lib/python3.10/config-3.10-darwin -D ammercoretest.python.version=10 build/build-python.hxml
+        haxe -D ammercoretest.python.includepaths="/Library/Frameworks/Python.framework/Versions/3.11/include/python3.11;/Library/Frameworks/Python.framework/Versions/3.11/include/python3.11" -D ammercoretest.python.librarypaths=/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/config-3.11-darwin -D ammercoretest.python.version=11 build/build-python.hxml
 
     - name: Compile tests (Windows)
       if: matrix.os == 'windows-latest'

--- a/src/ammer/core/Library.hx
+++ b/src/ammer/core/Library.hx
@@ -79,12 +79,40 @@ class Library {
     );
   }
 
+  public function staticCall(
+    ret:TypeMarshal,
+    args:Array<TypeMarshal>,
+    code:Expr,
+    outputExpr:String,
+    argExprs:Array<String>
+  ):String {
+    return library.staticCall(
+      ret,
+      args,
+      code,
+      outputExpr,
+      argExprs
+    );
+  }
+
   public function addCallback(
     ret:TypeMarshal,
     args:Array<TypeMarshal>,
     code:String
   ):String {
     return library.addCallback(
+      ret,
+      args,
+      code
+    );
+  }
+
+  public function addStaticCallback(
+    ret:TypeMarshal,
+    args:Array<TypeMarshal>,
+    code:Expr
+  ):String {
+    return library.addStaticCallback(
       ret,
       args,
       code

--- a/src/ammer/core/Library.hx
+++ b/src/ammer/core/Library.hx
@@ -58,12 +58,13 @@ class Library {
 
   /*
   public function addNamedFunction(
-        name:String,
-        ret:TTypeMarshal,
-        args:Array<TTypeMarshal>,
-        code:String,
-        options:FunctionOptions
-      )*/
+    name:String,
+    ret:TTypeMarshal,
+    args:Array<TTypeMarshal>,
+    code:String,
+    options:FunctionOptions
+  );
+  */
 
   public function closureCall(
     fn:String,

--- a/src/ammer/core/MarshalBytes.hx
+++ b/src/ammer/core/MarshalBytes.hx
@@ -10,12 +10,26 @@ typedef MarshalBytes<TTypeMarshal> = {
   get8:(self:Expr, index:Expr)->Expr,
   get16:(self:Expr, index:Expr)->Expr,
   get32:(self:Expr, index:Expr)->Expr,
+  get64:(self:Expr, index:Expr)->Expr,
 
   set8:(self:Expr, index:Expr, val:Expr)->Expr,
   set16:(self:Expr, index:Expr, val:Expr)->Expr,
   set32:(self:Expr, index:Expr, val:Expr)->Expr,
+  set64:(self:Expr, index:Expr, val:Expr)->Expr,
 
-  // TODO: endian variants for 16/32
+  get16be:(self:Expr, index:Expr)->Expr,
+  get32be:(self:Expr, index:Expr)->Expr,
+  get64be:(self:Expr, index:Expr)->Expr,
+  set16be:(self:Expr, index:Expr, val:Expr)->Expr,
+  set32be:(self:Expr, index:Expr, val:Expr)->Expr,
+  set64be:(self:Expr, index:Expr, val:Expr)->Expr,
+
+  get16le:(self:Expr, index:Expr)->Expr,
+  get32le:(self:Expr, index:Expr)->Expr,
+  get64le:(self:Expr, index:Expr)->Expr,
+  set16le:(self:Expr, index:Expr, val:Expr)->Expr,
+  set32le:(self:Expr, index:Expr, val:Expr)->Expr,
+  set64le:(self:Expr, index:Expr, val:Expr)->Expr,
 
   alloc:(size:Expr)->Expr,
   zalloc:(size:Expr)->Expr,
@@ -23,8 +37,8 @@ typedef MarshalBytes<TTypeMarshal> = {
   free:(self:Expr)->Expr,
   copy:(self:Expr, size:Expr)->Expr,
   blit:(source:Expr, sourcepos:Expr, dest:Expr, destpos:Expr, size:Expr)->Expr,
-
-  // TODO: offset ...?
+  offset:(self:Expr, pos:Expr)->Expr,
+  // TODO: fill?
 
   toHaxeCopy:(self:Expr, size:Expr)->Expr,
   fromHaxeCopy:(bytes:Expr)->Expr,

--- a/src/ammer/core/plat/BaseMarshal.hx
+++ b/src/ammer/core/plat/BaseMarshal.hx
@@ -200,8 +200,8 @@ abstract class BaseMarshal<
     l3Type: "float",
     mangled: "f32",
     l1l2: MARSHAL_CONVERT_DIRECT,
-    l2l3: MARSHAL_CONVERT_DIRECT, // cast?
-    l3l2: MARSHAL_CONVERT_DIRECT, // cast?
+    l2l3: MARSHAL_CONVERT_CAST("float"),
+    l3l2: MARSHAL_CONVERT_CAST("double"),
     l2l1: MARSHAL_CONVERT_DIRECT,
     arrayBits: 2,
   };

--- a/src/ammer/core/plat/Cpp.hx
+++ b/src/ammer/core/plat/Cpp.hx
@@ -202,6 +202,7 @@ void _ammer_ref_${config.name}_delete(_ammer_haxe_ref* ref) {
   }
 
   override function finalise(platConfig:CppConfig):Void {
+    // TODO: file dependency to trigger recompilation when stubs change
     var xml = new LineBuf()
       .ail('<files id="haxe">')
       .i()

--- a/src/ammer/core/plat/Eval.hx
+++ b/src/ammer/core/plat/Eval.hx
@@ -43,7 +43,7 @@ class Eval extends Base<
 (library
   (name ammer_core_${lib.config.name})
   (libraries haxe)
-  (c_names stubs)
+  (foreign_stubs (language c) (names stubs))
 )')
       ));
       ops.push(BOAlways(

--- a/src/ammer/core/plat/Java.hx
+++ b/src/ammer/core/plat/Java.hx
@@ -370,8 +370,6 @@ class JavaMarshal extends BaseMarshal<
   // Primitive types
   // https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/types.html#primitive_types
 
-  // TODO: javaMangle ...
-
   static function baseExtend(
     base:BaseTypeMarshal,
     ext:JavaTypeMarshalExt,
@@ -415,12 +413,11 @@ class JavaMarshal extends BaseMarshal<
 
   static final MARSHAL_UINT8 = baseExtend(BaseMarshal.baseUint8(), {
     primitive: true,
-    // TODO: there is no java.types.Uint8, so u8 arrays use i8
-    javaMangle: "B", //javaMangle: "Z",
+    javaMangle: "Z",
     javaFullName: "Boolean",
   }, {
-    // l1Type: "jboolean",
-    l1Type: "jbyte",
+    l1Type: "jboolean",
+    // TODO: there is no java.types.Uint8, so u8 arrays use i8
     arrayType: (macro : java.types.Int8),
   });
   static final MARSHAL_INT8 = baseExtend(BaseMarshal.baseInt8(), {

--- a/src/ammer/core/plat/Lua.hx
+++ b/src/ammer/core/plat/Lua.hx
@@ -134,7 +134,7 @@ static int _ammer_ref_getvalue(lua_State* _lua_state) {
     // TODO: name symbols with internalPrefix
     lb.ail('
 static int _ammer_lua_tobytesdata(lua_State* _lua_state) {
-  uint8_t* data = lua_touserdata(_lua_state, 1);
+  uint8_t* data = (uint8_t*)lua_touserdata(_lua_state, 1);
   uint32_t size = lua_tointeger(_lua_state, 2);
   lua_createtable(_lua_state, size, 0);
   for (int i = 0; i < size; i++) {
@@ -428,7 +428,7 @@ lua_setfield(_lua_state, -2, "high");'),
 
   static final MARSHAL_BYTES = baseExtend(BaseMarshal.baseBytesInternal(), {
     haxeType: (macro : lua.UserData),
-    l1l2: (l1, l2) -> '$l2 = lua_touserdata(_lua_state, $l1);',
+    l1l2: (l1, l2) -> '$l2 = (uint8_t*)lua_touserdata(_lua_state, $l1);',
     l2l1: MARSHAL_PUSH((l2) -> 'lua_pushlightuserdata(_lua_state, $l2);'),
   });
   function bytesInternalType():LuaTypeMarshal return MARSHAL_BYTES;
@@ -472,19 +472,19 @@ lua_setfield(_lua_state, -2, "high");'),
 
   function opaqueInternal(name:String):LuaTypeMarshal return baseExtend(BaseMarshal.baseOpaqueInternal(name), {
     haxeType: (macro : lua.UserData),
-    l1l2: (l1, l2) -> '$l2 = lua_touserdata(_lua_state, $l1);',
+    l1l2: (l1, l2) -> '$l2 = ($name)lua_touserdata(_lua_state, $l1);',
     l2l1: MARSHAL_PUSH((l2) -> 'lua_pushlightuserdata(_lua_state, $l2);'),
   });
 
   function structPtrDerefInternal(name:String):LuaTypeMarshal return baseExtend(BaseMarshal.baseStructPtrDerefInternal(name), {
     haxeType: (macro : lua.UserData),
-    l1l2: (l1, l2) -> '$l2 = lua_touserdata(_lua_state, $l1);',
+    l1l2: (l1, l2) -> '$l2 = ($name*)lua_touserdata(_lua_state, $l1);',
     l2l1: MARSHAL_PUSH((l2) -> 'lua_pushlightuserdata(_lua_state, $l2);'),
   });
 
   function arrayPtrInternalType(element:LuaTypeMarshal):LuaTypeMarshal return baseExtend(BaseMarshal.baseArrayPtrInternal(element), {
     haxeType: (macro : lua.UserData),
-    l1l2: (l1, l2) -> '$l2 = lua_touserdata(_lua_state, $l1);',
+    l1l2: (l1, l2) -> '$l2 = (${element.l2Type}*)lua_touserdata(_lua_state, $l1);',
     l2l1: MARSHAL_PUSH((l2) -> 'lua_pushlightuserdata(_lua_state, $l2);'),
   });
 

--- a/src/ammer/core/plat/None.hx
+++ b/src/ammer/core/plat/None.hx
@@ -63,6 +63,16 @@ class NoneLibrary extends BaseLibrary<
     return "#invalid#";
   }
 
+  public function staticCall(
+    ret:NoneTypeMarshal,
+    args:Array<NoneTypeMarshal>,
+    code:Expr,
+    outputExpr:String,
+    argExprs:Array<String>
+  ):String {
+    return "#invalid#";
+  }
+
   public function addCallback(
     ret:NoneTypeMarshal,
     args:Array<NoneTypeMarshal>,

--- a/src/ammer/core/plat/Python.hx
+++ b/src/ammer/core/plat/Python.hx
@@ -185,9 +185,8 @@ static PyObject* _ammer_haxe_scb;
 
     lb
       .ail('static PyObject *_ammer_init(PyObject *_python_self, PyObject *_python_args) {
-  PyObject *ex_int64;
-  // TODO: get rid of parsetuple
-  if (!PyArg_ParseTuple(_python_args, \"OO\", &ex_int64, &_ammer_haxe_scb)) return NULL;
+  PyObject *ex_int64 = PyTuple_GetItem(_python_args, 0);
+  _ammer_haxe_scb = PyTuple_GetItem(_python_args, 1);
   _ammer_haxe_int64_type = Py_TYPE(ex_int64);
   Py_XINCREF(_ammer_haxe_scb);
   Py_RETURN_NONE;
@@ -258,6 +257,7 @@ PyMODINIT_FUNC PyInit_${config.name}(void) {
       access: [APrivate, AStatic],
     });
     var callArgs = [ for (i => arg in args) macro $i{'arg$i'} ];
+    // TODO: why not call directly?
     tdef.fields.push({
       pos: options.pos,
       name: name,

--- a/src/ammer/core/utils/LineBuf.hx
+++ b/src/ammer/core/utils/LineBuf.hx
@@ -29,6 +29,11 @@ class LineBuf {
     return this;
   }
 
+  public function apply(f:LineBuf->Void):LineBuf {
+    f(this);
+    return this;
+  }
+
   public inline function a(val:String):LineBuf {
     if (condActive) {
       data.add(val);

--- a/test/src/TestHarness.macro.hx
+++ b/test/src/TestHarness.macro.hx
@@ -58,6 +58,7 @@ class TestHarness {
       #end
       #if (AMMER_TEST_JAVA || AMMER_TEST_JVM)
         javaIncludePaths: paths("java.includepaths"),
+        javaLibraryPaths: paths("java.librarypaths"),
       #end
       #if AMMER_TEST_LUA
         luaIncludePaths: paths("lua.includepaths"),

--- a/test/src/test/TestBytes.hx
+++ b/test/src/test/TestBytes.hx
@@ -15,25 +15,31 @@ class TestBytes extends TestBase {
 
     scope(testFromHaxeCopy);
     scope(testToHaxeCopy);
+
+    scope(testEndian);
+    scope(testOffset);
   }
 
   function testFromHaxeRef():Void {
-    run(macro var bytes = haxe.io.Bytes.ofString("hello world HELLO"));
+    run(macro var bytes = haxe.io.Bytes.ofString("hello world HELLO---"));
     run(macro var nativeBytes = $e{bytesType.fromHaxeRef(macro bytes)});
 
     assertEq(bytesType.get8 (macro nativeBytes.ptr, macro 0), macro "h".code  );
     assertEq(bytesType.get16(macro nativeBytes.ptr, macro 1), macro 0x6C65    );
     assertEq(bytesType.get32(macro nativeBytes.ptr, macro 3), macro 0x77206F6C);
+    assertEq(bytesType.get64(macro nativeBytes.ptr, macro 7), macro haxe.Int64.make(0x4C454820, 0x646C726F));
 
-    run(bytesType.set8 (macro nativeBytes.ptr, macro 5, macro 0x17      ));
-    run(bytesType.set16(macro nativeBytes.ptr, macro 6, macro 0x1920    ));
-    run(bytesType.set32(macro nativeBytes.ptr, macro 8, macro 0x22232425));
+    run(bytesType.set8 (macro nativeBytes.ptr, macro 5,  macro 0x17      ));
+    run(bytesType.set16(macro nativeBytes.ptr, macro 6,  macro 0x1920    ));
+    run(bytesType.set32(macro nativeBytes.ptr, macro 8,  macro 0x22232425));
+    run(bytesType.set64(macro nativeBytes.ptr, macro 12, macro haxe.Int64.make(0x26272829, 0x30313233)));
 
     run(macro nativeBytes.unref());
 
-    assertEq(macro bytes.get      (5), macro 0x17      );
-    assertEq(macro bytes.getUInt16(6), macro 0x1920    );
-    assertEq(macro bytes.getInt32 (8), macro 0x22232425);
+    assertEq(macro bytes.get      (5),  macro 0x17      );
+    assertEq(macro bytes.getUInt16(6),  macro 0x1920    );
+    assertEq(macro bytes.getInt32 (8),  macro 0x22232425);
+    assertEq(macro bytes.getInt64 (12), macro haxe.Int64.make(0x26272829, 0x30313233));
   }
 
   function testToHaxeRef():Void {
@@ -59,6 +65,47 @@ class TestBytes extends TestBase {
     run(macro var bytes = $e{bytesType.toHaxeCopy(macro nativeBytes, macro 4)});
     run(bytesType.set32(macro nativeBytes, macro 0, macro 0xCAFEFACE));
     assertEq(macro bytes.getInt32(0), macro 0xDEADFEED);
+  }
+
+  function testEndian():Void {
+    run(macro var bytes = $e{bytesType.zalloc(macro 10)});
+    run(macro $e{bytesType.set16(macro bytes, macro 0, macro 0xABCD)});
+    run(macro var le = ($e{bytesType.get8(macro bytes, macro 0)} == 0xCD));
+
+    run(macro $e{bytesType.set64(macro bytes, macro 0, macro haxe.Int64.make(0x01020304, 0x05060708))});
+    assertEq(bytesType.get8 (macro bytes, macro 1), macro (le ? 0x07       : 0x02));
+    assertEq(bytesType.get16(macro bytes, macro 1), macro (le ? 0x0607     : 0x0203));
+    assertEq(bytesType.get32(macro bytes, macro 1), macro (le ? 0x04050607 : 0x02030405));
+    assertEq(bytesType.get64(macro bytes, macro 1), macro (le ? haxe.Int64.make(0x00010203, 0x04050607) : haxe.Int64.make(0x02030405, 0x06070800)));
+
+    run(macro $e{bytesType.free(macro bytes)});
+    run(macro var bytes = $e{bytesType.zalloc(macro 8)});
+
+    run(macro $e{bytesType.set16le(macro bytes, macro 0, macro 0x0102)});
+    assertEq(bytesType.get8(macro bytes, macro 0), macro 0x02);
+
+    run(macro $e{bytesType.set32le(macro bytes, macro 0, macro 0x01020304)});
+    assertEq(bytesType.get8(macro bytes, macro 0), macro 0x04);
+
+    run(macro $e{bytesType.set64le(macro bytes, macro 0, macro haxe.Int64.make(0x01020304, 0x05060708))});
+    assertEq(bytesType.get8(macro bytes, macro 0), macro 0x08);
+
+    run(macro $e{bytesType.set16be(macro bytes, macro 0, macro 0x0102)});
+    assertEq(bytesType.get8(macro bytes, macro 0), macro 0x01);
+
+    run(macro $e{bytesType.set32be(macro bytes, macro 0, macro 0x01020304)});
+    assertEq(bytesType.get8(macro bytes, macro 0), macro 0x01);
+
+    run(macro $e{bytesType.set64be(macro bytes, macro 0, macro haxe.Int64.make(0x01020304, 0x05060708))});
+    assertEq(bytesType.get8(macro bytes, macro 0), macro 0x01);
+  }
+
+  function testOffset():Void {
+    run(macro var a = haxe.io.Bytes.ofString("hello world HELLO"));
+    run(macro var b = $e{bytesType.fromHaxeCopy(macro a)});
+    run(macro var c = $e{bytesType.offset(macro b, macro 6)});
+    run(macro var d = $e{bytesType.toHaxeCopy(macro c, macro 11)});
+    assertEq(macro d.toString(), macro "world HELLO");
   }
 }
 

--- a/test/src/test/TestCallbacks.hx
+++ b/test/src/test/TestCallbacks.hx
@@ -5,6 +5,11 @@ package test;
 class TestCallbacks extends TestBase {
   public function new() {
     super("TestCallbacks");
+    testClosures();
+    testStatic();
+  }
+
+  function testClosures():Void {
     var typeNative = cType("void* field_cl; void* field_cl2;");
     var closureType = marshal.closure(marshal.int32(), [marshal.int32(), marshal.int32()]);
     var closureType2 = marshal.closure(marshal.void(), []);
@@ -87,6 +92,32 @@ class TestCallbacks extends TestBase {
       assertEq(macro callLog, macro 2);
       run(type.free(macro struct));
     });
+  }
+
+  function testStatic():Void {
+    var cb = lib.addStaticCallback(
+      marshal.int32(),
+      [marshal.int32(), marshal.int32()],
+      macro return arg0 + arg1
+    );
+    var caller = lib.addFunction(
+      marshal.int32(),
+      [],
+      '_return = $cb(11, 22);'
+    );
+    assertEq(macro $caller(), macro 33);
+
+    var cb = lib.addStaticCallback(
+      marshal.string(),
+      [marshal.int32(), marshal.string()],
+      macro return '$arg0$arg1'
+    );
+    var caller = lib.addFunction(
+      marshal.string(),
+      [marshal.int32()],
+      '_return = $cb(_arg0, "hello");'
+    );
+    assertEq(macro $caller(5), macro "5hello");
   }
 }
 


### PR DESCRIPTION
Summary of changes:

- Small CI fixes, `eval` build matches `haxe` again.
- Added static callbacks, i.e. calls directly to a fragment of Haxe code without a closure context. In `ammer` these will correspond to callbacks to `static function`s, hence the name.
- Added little- and big-endian variants of `Bytes` operations (`getXle`, `setXle`, `getXbe`, `setXbe`), in addition to 64-bit operations (`get64`, `set64`). Functions without an `le` or `be` suffix will default to the machine endianness.