### PR TITLE
Update `master`

### DIFF
--- a/src/ammer/core/BuildOp.hx
+++ b/src/ammer/core/BuildOp.hx
@@ -35,8 +35,9 @@ enum BuildOpCommand {
   WriteData(_:haxe.io.Bytes);
   CompileObject(lang:LibraryLanguage, opt:MakeCompileOptions);
   LinkLibrary(lang:LibraryLanguage, opt:MakeLinkOptions);
+  LinkExecutable(lang:LibraryLanguage, opt:MakeLinkOptions);
   EnsureDirectory;
-  Command(cmd:String, args:Array<String>);
+  Command(cmd:String, args:Array<String>, ?process:(code:Int, proc:sys.io.Process)->Void);
 }
 
 typedef MakeCompileOptions = {

--- a/src/ammer/core/Library.hx
+++ b/src/ammer/core/Library.hx
@@ -30,6 +30,10 @@ class Library {
     }));
   }
 
+  public function outputPathRelative():String {
+    return this.library.outputPathRelative;
+  }
+
   public function addInclude(include:SourceInclude):Void {
     library.addInclude(include);
   }

--- a/src/ammer/core/Marshal.hx
+++ b/src/ammer/core/Marshal.hx
@@ -70,6 +70,7 @@ class Marshal {
   public function int16():TypeMarshal return marshal.int16();
   public function int32():TypeMarshal return marshal.int32();
   public function int64():TypeMarshal return marshal.int64();
+  public function enumInt(name:String, type:TypeMarshal):TypeMarshal return marshal.enumInt(name, type);
   public function float32():TypeMarshal return marshal.float32();
   public function float64():TypeMarshal return marshal.float64();
   public function bytes():MarshalBytes<TypeMarshal> return marshal.bytes();

--- a/src/ammer/core/MarshalArray.hx
+++ b/src/ammer/core/MarshalArray.hx
@@ -14,6 +14,7 @@ typedef MarshalArray<TTypeMarshal> = {
   alloc:(size:Expr)->Expr,
   zalloc:(size:Expr)->Expr,
   free:(self:Expr)->Expr,
+  nullPtr:Null<Expr>,
 
   // TODO: offset? other functions from Bytes, zalloc, copy, blit
 

--- a/src/ammer/core/plat/Base.hx
+++ b/src/ammer/core/plat/Base.hx
@@ -53,9 +53,8 @@ abstract class Base<
   function baseDynamicLinkProgram(options:{
     ?includePaths:Array<String>,
     ?libraryPaths:Array<String>,
-    ?defines:TLibrary->Array<String>,
     ?linkNames:Array<String>,
-    ?outputPath:TLibrary->String,
+    ?defines:Array<String>,
   }):BuildProgram {
     var ops:Array<BuildOp> = [];
     for (lib in libraries) {
@@ -80,20 +79,17 @@ abstract class Base<
         File('${config.buildPath}/${lib.config.name}/lib.$platformId.%OBJ%'),
         File('${config.buildPath}/${lib.config.name}/lib.$platformId.$ext'),
         CompileObject(lib.config.language, {
-          defines: (options.defines != null ? options.defines(lib) : lib.config.defines),
+          defines: lib.config.defines.concat(options.defines != null ? options.defines : []),
           includePaths: (options.includePaths != null ? options.includePaths : [])
             .concat(lib.config.includePaths),
         })
       ));
-      var outputPath = options.outputPath != null
-        ? options.outputPath(lib)
-        : '${config.outputPath}/%LIB%${lib.config.name}.%DLL%';
-      var linkName = outputPath.split("/").pop();
+      var linkName = lib.outputPathRelative.split("/").pop();
       ops.push(BODependent(
-        File(outputPath),
+        File('${config.outputPath}/${lib.outputPathRelative}'),
         File('${config.buildPath}/${lib.config.name}/lib.$platformId.%OBJ%'),
         LinkLibrary(lib.config.language, {
-          defines: (options.defines != null ? options.defines(lib) : lib.config.defines),
+          defines: lib.config.defines.concat(options.defines != null ? options.defines : []),
           libraryPaths: (options.libraryPaths != null ? options.libraryPaths : [])
             .concat(lib.config.libraryPaths),
           libraries: (options.linkNames != null ? options.linkNames : [])

--- a/src/ammer/core/plat/BaseLibrary.hx
+++ b/src/ammer/core/plat/BaseLibrary.hx
@@ -72,10 +72,11 @@ abstract class BaseLibrary<
 #include <inttypes.h>
 #include <stdbool.h>
 #include <string.h>
+#include <stdio.h>
 #ifdef _WIN32
-  #define LIB_EXPORT __declspec(dllexport)
+  #define _AMMER_LIB_EXPORT __declspec(dllexport)
 #else
-  #define LIB_EXPORT
+  #define _AMMER_LIB_EXPORT
 #endif
 #ifdef _MSC_VER
   #define _AMMER_BIG_ENDIAN 0

--- a/src/ammer/core/plat/BaseLibrary.hx
+++ b/src/ammer/core/plat/BaseLibrary.hx
@@ -38,6 +38,7 @@ abstract class BaseLibrary<
   >
 > {
   public var marshal:TMarshal;
+  public var outputPathRelative:String;
 
   var platform:TPlatform;
   var config:TLibraryConfig;
@@ -124,8 +125,11 @@ abstract class BaseLibrary<
 #endif");
   }
 
-  function finalise(config:TConfig):Void {
+  function finalise(platConfig:TConfig):Void {
     if (finalised) throw "library was already finalised";
+    if (outputPathRelative == null) {
+      outputPathRelative = '%LIB%${config.name}.%DLL%';
+    }
     finalised = true;
     for (tdef in tdefs) {
       TypeUtils.defineType(tdef); // TODO: moduleDependency arg

--- a/src/ammer/core/plat/BaseMarshal.hx
+++ b/src/ammer/core/plat/BaseMarshal.hx
@@ -169,6 +169,20 @@ abstract class BaseMarshal<
   abstract public function uint64():TTypeMarshal;
   abstract public function int64():TTypeMarshal;
 
+  static function baseEnumInt(name:String, type:BaseTypeMarshal):BaseTypeMarshal return {
+    haxeType: type.haxeType,
+    l1Type: type.l1Type,
+    l2Type: type.l2Type,
+    l3Type: name,
+    mangled: type.mangled,
+    l1l2: type.l1l2,
+    l2l3: MARSHAL_CONVERT_CAST(name),
+    l3l2: MARSHAL_CONVERT_CAST(type.l2Type),
+    l2l1: type.l2l1,
+    arrayBits: type.arrayBits,
+  };
+  abstract public function enumInt(name:String, type:TTypeMarshal):TTypeMarshal;
+
   static function baseFloat32():BaseTypeMarshal return {
     haxeType: (macro : Single),
     l1Type: "float",

--- a/src/ammer/core/plat/BaseMarshal.hx
+++ b/src/ammer/core/plat/BaseMarshal.hx
@@ -348,7 +348,7 @@ ${library.config.memcpyFunction}(_return, _arg0, _arg1);'
 
       alloc: alloc,
       zalloc: (size) -> macro $zalloc($size),
-      nullPtr: macro $e{nullPtr}(),
+      nullPtr: macro $nullPtr(),
       free: (self) -> macro $free($self),
       copy: (self, size) -> macro $copy($self, $size),
       blit: blit,
@@ -680,6 +680,11 @@ ${library.config.memcpyFunction}(_return, _arg0, sizeof($name));'
       [type],
       '${library.config.freeFunction}(_arg0);'
     );
+    var nullPtr = library.addFunction(
+      type,
+      [],
+      '_return = (${type.l3Type})0;'
+    );
     return cacheArray[cacheKey] = {
       type: type,
       get: get,
@@ -688,6 +693,7 @@ ${library.config.memcpyFunction}(_return, _arg0, sizeof($name));'
       alloc: alloc,
       zalloc: (size) -> macro $zalloc($size),
       free: (self) -> macro $free($self),
+      nullPtr: macro $nullPtr(),
 
       vectorType: platform.vectorType,
       vectorTypePath: platform.vectorType != null ? TypeUtils.complexTypeToPath(platform.vectorType) : null,

--- a/src/ammer/core/plat/Cpp.hx
+++ b/src/ammer/core/plat/Cpp.hx
@@ -232,6 +232,7 @@ void _ammer_ref_${config.name}_delete(_ammer_haxe_ref* ref) {
     //  pos: config.pos
     //});
     super.finalise(platConfig);
+    outputPathRelative = null;
   }
 
   override public function addInclude(include:SourceInclude):Void {

--- a/src/ammer/core/plat/Cpp.hx
+++ b/src/ammer/core/plat/Cpp.hx
@@ -379,20 +379,20 @@ class CppMarshal extends BaseMarshal<
 > {
   static function baseExtend(
     base:BaseTypeMarshal,
-    ?over:BaseTypeMarshal.BaseTypeMarshalOpt
+    over:BaseTypeMarshal.BaseTypeMarshalOpt
   ):CppTypeMarshal {
     return {
-      haxeType:  over != null && over.haxeType  != null ? over.haxeType  : base.haxeType,
-      l1Type:    over != null && over.l1Type    != null ? over.l1Type    : base.l1Type,
-      l2Type:    over != null && over.l2Type    != null ? over.l2Type    : base.l2Type,
-      l3Type:    over != null && over.l3Type    != null ? over.l3Type    : base.l3Type,
-      mangled:   over != null && over.mangled   != null ? over.mangled   : base.mangled,
-      l1l2:      over != null && over.l1l2      != null ? over.l1l2      : base.l1l2,
-      l2l3:      over != null && over.l2l3      != null ? over.l2l3      : base.l2l3,
-      l3l2:      over != null && over.l3l2      != null ? over.l3l2      : base.l3l2,
-      l2l1:      over != null && over.l2l1      != null ? over.l2l1      : base.l2l1,
-      arrayBits: over != null && over.arrayBits != null ? over.arrayBits : base.arrayBits,
-      arrayType: over != null && over.arrayType != null ? over.arrayType : base.arrayType,
+      haxeType:  over.haxeType  != null ? over.haxeType  : base.haxeType,
+      l1Type:    over.l1Type    != null ? over.l1Type    : base.l1Type,
+      l2Type:    over.l2Type    != null ? over.l2Type    : base.l2Type,
+      l3Type:    over.l3Type    != null ? over.l3Type    : base.l3Type,
+      mangled:   over.mangled   != null ? over.mangled   : base.mangled,
+      l1l2:      over.l1l2      != null ? over.l1l2      : base.l1l2,
+      l2l3:      over.l2l3      != null ? over.l2l3      : base.l2l3,
+      l3l2:      over.l3l2      != null ? over.l3l2      : base.l3l2,
+      l2l1:      over.l2l1      != null ? over.l2l1      : base.l2l1,
+      arrayBits: over.arrayBits != null ? over.arrayBits : base.arrayBits,
+      arrayType: over.arrayType != null ? over.arrayType : base.arrayType,
     };
   }
 
@@ -424,7 +424,7 @@ class CppMarshal extends BaseMarshal<
   // result in the type being represented more "cleanly" in C++, but then it
   // would not as easily be assignable to/from integers
   public function enumInt(name:String, type:CppTypeMarshal):CppTypeMarshal
-    return baseExtend(BaseMarshal.baseEnumInt(name, type));
+    return baseExtend(BaseMarshal.baseEnumInt(name, type), {});
 
   static final MARSHAL_FLOAT32 = baseExtend(BaseMarshal.baseFloat32(), {arrayType: (macro : cpp.Float32)});
   static final MARSHAL_FLOAT64 = baseExtend(BaseMarshal.baseFloat64(), {arrayType: (macro : cpp.Float64)});

--- a/src/ammer/core/plat/Cpp.hx
+++ b/src/ammer/core/plat/Cpp.hx
@@ -419,6 +419,12 @@ class CppMarshal extends BaseMarshal<
   public function uint64():CppTypeMarshal return MARSHAL_UINT64;
   public function int64():CppTypeMarshal return MARSHAL_INT64;
 
+  // setting `haxeType` to a type defined with `defineNativeType(name)` would
+  // result in the type being represented more "cleanly" in C++, but then it
+  // would not as easily be assignable to/from integers
+  public function enumInt(name:String, type:CppTypeMarshal):CppTypeMarshal
+    return baseExtend(BaseMarshal.baseEnumInt(name, type));
+
   static final MARSHAL_FLOAT32 = baseExtend(BaseMarshal.baseFloat32(), {arrayType: (macro : cpp.Float32)});
   static final MARSHAL_FLOAT64 = baseExtend(BaseMarshal.baseFloat64(), {arrayType: (macro : cpp.Float64)});
   public function float32():CppTypeMarshal return MARSHAL_FLOAT32;

--- a/src/ammer/core/plat/Cs.hx
+++ b/src/ammer/core/plat/Cs.hx
@@ -362,6 +362,9 @@ class CsMarshal extends BaseMarshal<
   public function uint64():CsTypeMarshal return MARSHAL_UINT64;
   public function int64():CsTypeMarshal return MARSHAL_INT64;
 
+  public function enumInt(name:String, type:CsTypeMarshal):CsTypeMarshal
+    return baseExtend(BaseMarshal.baseEnumInt(name, type), {primitive: true, csType: type.csType});
+
   static final MARSHAL_FLOAT32 = baseExtend(BaseMarshal.baseFloat32(), {primitive: true, csType: "float"}, {
     arrayType: (macro : Single),
   });

--- a/src/ammer/core/plat/Cs.hx
+++ b/src/ammer/core/plat/Cs.hx
@@ -32,9 +32,7 @@ class Cs extends Base<
   }
 
   public function finalise():BuildProgram {
-    return baseDynamicLinkProgram({
-      outputPath: lib -> '${config.outputPath}/${lib.config.name}.dll',
-    });
+    return baseDynamicLinkProgram({});
   }
 }
 
@@ -118,6 +116,7 @@ LIB_EXPORT int _ammer_init(void* delegates[${delegateCtr}]) {
       params: [macro $v{lbImport.done()}],
       name: ":classCode",
     });
+    outputPathRelative = '${config.name}.dll';
     super.finalise(platConfig);
   }
 

--- a/src/ammer/core/plat/Cs.hx
+++ b/src/ammer/core/plat/Cs.hx
@@ -51,6 +51,7 @@ class CsLibrary extends BaseLibrary<
   var haxeRefTdefs:Map<String, TypeDefinition> = [];
 
   var lbImport = new LineBuf();
+  var export:String;
 
   public function new(platform:Cs, config:CsLibraryConfig) {
     super(platform, config, new CsMarshal(this));
@@ -58,12 +59,13 @@ class CsLibrary extends BaseLibrary<
       pos: config.pos,
       name: ":nativeGen",
     });
+    export = '${config.language.match(Cpp | ObjectiveCpp) ? 'extern "C" ' : ""}_AMMER_LIB_EXPORT';
     lb
       .ail("void** _ammer_delegates;");
-    lb.ail('LIB_EXPORT void _ammer_cs_tohaxecopy(uint8_t* data, int size, uint8_t* res, int res_size) {
+    lb.ail('$export void _ammer_cs_tohaxecopy(uint8_t* data, int size, uint8_t* res, int res_size) {
   ${config.memcpyFunction}(res, data, size);
 }
-LIB_EXPORT uint8_t* _ammer_cs_fromhaxecopy(uint8_t* data, int size) {
+$export uint8_t* _ammer_cs_fromhaxecopy(uint8_t* data, int size) {
   uint8_t* res = (uint8_t*)${config.mallocFunction}(size);
   ${config.memcpyFunction}(res, data, size);
   return res;
@@ -93,7 +95,7 @@ LIB_EXPORT uint8_t* _ammer_cs_fromhaxecopy(uint8_t* data, int size) {
   override function finalise(platConfig:CsConfig):Void {
     lb
       .ail('
-LIB_EXPORT int _ammer_init(void* delegates[${delegateCtr}]) {
+$export int _ammer_init(void* delegates[${delegateCtr}]) {
   _ammer_delegates = (void**)${config.mallocFunction}(sizeof(void*) * ${delegateCtr});
   ${config.memcpyFunction}(_ammer_delegates, delegates, sizeof(void*) * ${delegateCtr});
   return 0;
@@ -128,7 +130,7 @@ LIB_EXPORT int _ammer_init(void* delegates[${delegateCtr}]) {
     options:FunctionOptions
   ):Expr {
     lb
-      .ai('LIB_EXPORT ${ret.l1Type} $name(')
+      .ai('$export ${ret.l1Type} $name(')
       .mapi(args, (idx, arg) -> '${arg.l1Type} _l1_arg_${idx}', ", ")
       .a(args.length == 0 ? "void" : "")
       .al(") {")

--- a/src/ammer/core/plat/Cs.hx
+++ b/src/ammer/core/plat/Cs.hx
@@ -109,9 +109,8 @@ $export int _ammer_init(void* delegates[${delegateCtr}]) {
         .a(")] System.IntPtr[] delegates);")
       .ail("static int _ammer_native = _ammer_init(new System.IntPtr[]{")
         .lmap([ for (idx in 0...delegateCtr) idx ], (idx) ->
-          // TODO: what even is this
           'System.Runtime.InteropServices.Marshal.GetFunctionPointerForDelegate('
-            + 'System.Delegate.CreateDelegate(typeof(ClosureDelegate${idx}), typeof(CoreExtern_example), "ImplClosureDelegate${idx}")),')
+            + 'System.Delegate.CreateDelegate(typeof(ClosureDelegate${idx}), typeof(CoreExtern_${config.name}), "ImplClosureDelegate${idx}")),')
       .ail("});");
     tdef.meta.push({
       pos: Context.currentPos(),

--- a/src/ammer/core/plat/Eval.hx
+++ b/src/ammer/core/plat/Eval.hx
@@ -248,6 +248,7 @@ CAMLprim value _ammer_init(value scb, value decode_i64, value encode_i64, value 
       .addBuf(lbInit)
       .ail("];");
     super.finalise(platConfig);
+    outputPathRelative = null; // TODO: output path does not really make sense here, but what about .cmxo files?
   }
 
   public function addNamedFunction(

--- a/src/ammer/core/plat/Eval.hx
+++ b/src/ammer/core/plat/Eval.hx
@@ -435,21 +435,21 @@ class EvalMarshal extends BaseMarshal<
 > {
   static function baseExtend(
     base:BaseTypeMarshal,
-    ?over:BaseTypeMarshal.BaseTypeMarshalOpt
+    over:BaseTypeMarshal.BaseTypeMarshalOpt
   ):EvalTypeMarshal {
     return {
-      haxeType:  over != null && over.haxeType  != null ? over.haxeType  : base.haxeType,
+      haxeType:  over.haxeType  != null ? over.haxeType  : base.haxeType,
       // L1 type is always "value", an OCaml tagged pointer
       l1Type:   "value",
-      l2Type:    over != null && over.l2Type    != null ? over.l2Type    : base.l2Type,
-      l3Type:    over != null && over.l3Type    != null ? over.l3Type    : base.l3Type,
-      mangled:   over != null && over.mangled   != null ? over.mangled   : base.mangled,
-      l1l2:      over != null && over.l1l2      != null ? over.l1l2      : base.l1l2,
-      l2l3:      over != null && over.l2l3      != null ? over.l2l3      : base.l2l3,
-      l3l2:      over != null && over.l3l2      != null ? over.l3l2      : base.l3l2,
-      l2l1:      over != null && over.l2l1      != null ? over.l2l1      : base.l2l1,
-      arrayBits: over != null && over.arrayBits != null ? over.arrayBits : base.arrayBits,
-      arrayType: over != null && over.arrayType != null ? over.arrayType : base.arrayType,
+      l2Type:    over.l2Type    != null ? over.l2Type    : base.l2Type,
+      l3Type:    over.l3Type    != null ? over.l3Type    : base.l3Type,
+      mangled:   over.mangled   != null ? over.mangled   : base.mangled,
+      l1l2:      over.l1l2      != null ? over.l1l2      : base.l1l2,
+      l2l3:      over.l2l3      != null ? over.l2l3      : base.l2l3,
+      l3l2:      over.l3l2      != null ? over.l3l2      : base.l3l2,
+      l2l1:      over.l2l1      != null ? over.l2l1      : base.l2l1,
+      arrayBits: over.arrayBits != null ? over.arrayBits : base.arrayBits,
+      arrayType: over.arrayType != null ? over.arrayType : base.arrayType,
     };
   }
 
@@ -524,7 +524,7 @@ $l1 = caml_callback(_ammer_haxe_encode_i64, _eval_tmp);',
   public function int64():EvalTypeMarshal return MARSHAL_INT64;
 
   public function enumInt(name:String, type:EvalTypeMarshal):EvalTypeMarshal
-    return baseExtend(BaseMarshal.baseEnumInt(name, type));
+    return baseExtend(BaseMarshal.baseEnumInt(name, type), {});
 
   static final MARSHAL_FLOAT32 = baseExtend(BaseMarshal.baseFloat64As32(), {
     l1l2: (l1, l2) -> '$l2 = Tag_val($l1) == 0 ? ((double)Int32_val(Field($l1, 0))) : Double_val(Field($l1, 0));',

--- a/src/ammer/core/plat/Eval.hx
+++ b/src/ammer/core/plat/Eval.hx
@@ -522,6 +522,9 @@ $l1 = caml_callback(_ammer_haxe_encode_i64, _eval_tmp);',
   public function uint64():EvalTypeMarshal return MARSHAL_UINT64;
   public function int64():EvalTypeMarshal return MARSHAL_INT64;
 
+  public function enumInt(name:String, type:EvalTypeMarshal):EvalTypeMarshal
+    return baseExtend(BaseMarshal.baseEnumInt(name, type));
+
   static final MARSHAL_FLOAT32 = baseExtend(BaseMarshal.baseFloat64As32(), {
     l1l2: (l1, l2) -> '$l2 = Tag_val($l1) == 0 ? ((double)Int32_val(Field($l1, 0))) : Double_val(Field($l1, 0));',
     l2l1: (l2, l1) -> '$l1 = caml_alloc(1, 1);

--- a/src/ammer/core/plat/Hashlink.hx
+++ b/src/ammer/core/plat/Hashlink.hx
@@ -425,6 +425,9 @@ $l1->low = (int32_t)($l2 & 0xFFFFFFFF);',
   public function uint64():HashlinkTypeMarshal return MARSHAL_UINT64;
   public function int64():HashlinkTypeMarshal return MARSHAL_INT64;
 
+  public function enumInt(name:String, type:HashlinkTypeMarshal):HashlinkTypeMarshal
+    return baseExtend(BaseMarshal.baseEnumInt(name, type), {hlType: type.hlType});
+
   static final MARSHAL_FLOAT32 = baseExtend(BaseMarshal.baseFloat32(), {hlType: "_F32"}, {
     arrayType: (macro : hl.F32),
   });

--- a/src/ammer/core/plat/Hashlink.hx
+++ b/src/ammer/core/plat/Hashlink.hx
@@ -40,9 +40,6 @@ class Hashlink extends Base<
       includePaths: config.hlIncludePaths,
       libraryPaths: config.hlLibraryPaths,
       linkNames: [BuildProgram.useMSVC ? "libhl" : "hl"],
-      outputPath: lib -> config.hlc
-        ? '${config.outputPath}/lib${lib.config.name}.%DLL%'
-        : '${config.outputPath}/${lib.config.name}.hdll',
     });
   }
 }
@@ -171,6 +168,7 @@ DEFINE_PRIM(_VOID, _ammer_init, _OBJ(_I32 _I32) _OBJ(_BYTES _I32) _ARR);');
       ),
       access: [APrivate, AStatic],
     });
+    outputPathRelative = platConfig.hlc ? 'lib${config.name}.%DLL%' : '${config.name}.hdll';
     super.finalise(platConfig);
   }
 

--- a/src/ammer/core/plat/Java.hx
+++ b/src/ammer/core/plat/Java.hx
@@ -498,6 +498,13 @@ class JavaMarshal extends BaseMarshal<
   public function uint64():JavaTypeMarshal return MARSHAL_UINT64;
   public function int64():JavaTypeMarshal return MARSHAL_INT64;
 
+  public function enumInt(name:String, type:JavaTypeMarshal):JavaTypeMarshal
+    return baseExtend(BaseMarshal.baseEnumInt(name, type), {
+      primitive: true,
+      javaMangle: type.javaMangle,
+      javaFullName: type.javaFullName,
+    });
+
   static final MARSHAL_FLOAT32 = baseExtend(BaseMarshal.baseFloat32(), {
     primitive: true,
     javaMangle: "F",

--- a/src/ammer/core/plat/Lua.hx
+++ b/src/ammer/core/plat/Lua.hx
@@ -326,21 +326,21 @@ class LuaMarshal extends BaseMarshal<
 
   static function baseExtend(
     base:BaseTypeMarshal,
-    ?over:BaseTypeMarshal.BaseTypeMarshalOpt
+    over:BaseTypeMarshal.BaseTypeMarshalOpt
   ):LuaTypeMarshal {
     return {
-      haxeType:  over != null && over.haxeType  != null ? over.haxeType  : base.haxeType,
+      haxeType:  over.haxeType  != null ? over.haxeType  : base.haxeType,
       // L1 type is always "int", representing a stack offset
       l1Type:   "int",
-      l2Type:    over != null && over.l2Type    != null ? over.l2Type    : base.l2Type,
-      l3Type:    over != null && over.l3Type    != null ? over.l3Type    : base.l3Type,
-      mangled:   over != null && over.mangled   != null ? over.mangled   : base.mangled,
-      l1l2:      over != null && over.l1l2      != null ? over.l1l2      : base.l1l2,
-      l2l3:      over != null && over.l2l3      != null ? over.l2l3      : base.l2l3,
-      l3l2:      over != null && over.l3l2      != null ? over.l3l2      : base.l3l2,
-      l2l1:      over != null && over.l2l1      != null ? over.l2l1      : base.l2l1,
-      arrayBits: over != null && over.arrayBits != null ? over.arrayBits : base.arrayBits,
-      arrayType: over != null && over.arrayType != null ? over.arrayType : base.arrayType,
+      l2Type:    over.l2Type    != null ? over.l2Type    : base.l2Type,
+      l3Type:    over.l3Type    != null ? over.l3Type    : base.l3Type,
+      mangled:   over.mangled   != null ? over.mangled   : base.mangled,
+      l1l2:      over.l1l2      != null ? over.l1l2      : base.l1l2,
+      l2l3:      over.l2l3      != null ? over.l2l3      : base.l2l3,
+      l3l2:      over.l3l2      != null ? over.l3l2      : base.l3l2,
+      l2l1:      over.l2l1      != null ? over.l2l1      : base.l2l1,
+      arrayBits: over.arrayBits != null ? over.arrayBits : base.arrayBits,
+      arrayType: over.arrayType != null ? over.arrayType : base.arrayType,
     };
   }
 
@@ -410,7 +410,7 @@ lua_setfield(_lua_state, -2, "high");'),
   public function int64():LuaTypeMarshal return MARSHAL_INT64;
 
   public function enumInt(name:String, type:LuaTypeMarshal):LuaTypeMarshal
-    return baseExtend(BaseMarshal.baseEnumInt(name, type));
+    return baseExtend(BaseMarshal.baseEnumInt(name, type), {});
 
   static final MARSHAL_FLOAT32 = baseExtend(BaseMarshal.baseFloat64As32(), {
     l1l2: (l1, l2) -> '$l2 = lua_tonumber(_lua_state, $l1);',

--- a/src/ammer/core/plat/Lua.hx
+++ b/src/ammer/core/plat/Lua.hx
@@ -409,6 +409,9 @@ lua_setfield(_lua_state, -2, "high");'),
   public function uint64():LuaTypeMarshal return MARSHAL_UINT64;
   public function int64():LuaTypeMarshal return MARSHAL_INT64;
 
+  public function enumInt(name:String, type:LuaTypeMarshal):LuaTypeMarshal
+    return baseExtend(BaseMarshal.baseEnumInt(name, type));
+
   static final MARSHAL_FLOAT32 = baseExtend(BaseMarshal.baseFloat64As32(), {
     l1l2: (l1, l2) -> '$l2 = lua_tonumber(_lua_state, $l1);',
     l2l1: MARSHAL_PUSH((l2) -> 'lua_pushnumber(_lua_state, $l2);'),

--- a/src/ammer/core/plat/Lua.hx
+++ b/src/ammer/core/plat/Lua.hx
@@ -62,8 +62,8 @@ class LuaLibrary extends BaseLibrary<
     }
     lb.ail('
 static int32_t _ammer_ctr = 0;
-static const char *_ammer_registry_name = "${config.internalPrefix}registry";
-static const char *_ammer_registry_scb = "${config.internalPrefix}scb";
+static const char *_ammer_registry_name = "${config.internalPrefix}_${config.name}_registry";
+static const char *_ammer_registry_scb = "${config.internalPrefix}_${config.name}_scb";
 static lua_State* _ammer_lua_state; // TODO: multiple threads?
 typedef struct { int32_t value; int32_t refcount; } _ammer_haxe_ref;
 static int _ammer_ref_create(lua_State* _lua_state) {

--- a/src/ammer/core/plat/Lua.hx
+++ b/src/ammer/core/plat/Lua.hx
@@ -53,10 +53,14 @@ class LuaLibrary extends BaseLibrary<
   public function new(platform:Lua, config:LuaLibraryConfig) {
     super(platform, config, new LuaMarshal(this));
     // TODO: internalPrefix
-    lb.ail('#include <lua.h>
+    if (config.language.match(Cpp | ObjectiveCpp)) {
+      lb.ail('#include <lua.hpp>');
+    } else {
+      lb.ail('#include <lua.h>
 #include <lualib.h>
-#include <lauxlib.h>
-
+#include <lauxlib.h>');
+    }
+    lb.ail('
 static int32_t _ammer_ctr = 0;
 static const char *_ammer_registry_name = "${config.internalPrefix}registry";
 static const char *_ammer_registry_scb = "${config.internalPrefix}scb";
@@ -131,6 +135,7 @@ static int _ammer_ref_getvalue(lua_State* _lua_state) {
       access: [APrivate, AStatic],
     });
 
+    var export = config.language.match(Cpp | ObjectiveCpp) ? 'extern "C" ' : "";
     // TODO: name symbols with internalPrefix
     lb.ail('
 static int _ammer_lua_tobytesdata(lua_State* _lua_state) {
@@ -158,7 +163,7 @@ static int _ammer_lua_frombytesdata(lua_State* _lua_state) {
   lua_pushlightuserdata(_lua_state, data);
   return 1;
 }
-int _ammer_init(lua_State* _lua_state) {
+${export}int _ammer_init(lua_State* _lua_state) {
   luaL_Reg _init_wrap[] = {
 ').addBuf(lbInit).ail('
     {"_ammer_lua_tobytesdata", _ammer_lua_tobytesdata},

--- a/src/ammer/core/plat/Neko.hx
+++ b/src/ammer/core/plat/Neko.hx
@@ -33,7 +33,6 @@ class Neko extends Base<
       includePaths: config.nekoIncludePaths,
       libraryPaths: config.nekoLibraryPaths,
       linkNames: ["neko"],
-      outputPath: lib -> '${config.outputPath}/${lib.config.name}.ndll',
     });
   }
 }
@@ -169,6 +168,7 @@ value* _ammer_haxe_scb;
   return val_null;
 }
 DEFINE_PRIM(_ammer_init, 3);');
+    outputPathRelative = '${config.name}.ndll';
     super.finalise(platConfig);
   }
 

--- a/src/ammer/core/plat/Neko.hx
+++ b/src/ammer/core/plat/Neko.hx
@@ -376,21 +376,21 @@ class NekoMarshal extends BaseMarshal<
 > {
   static function baseExtend(
     base:BaseTypeMarshal,
-    ?over:BaseTypeMarshal.BaseTypeMarshalOpt
+    over:BaseTypeMarshal.BaseTypeMarshalOpt
   ):NekoTypeMarshal {
     return {
-      haxeType:  over != null && over.haxeType  != null ? over.haxeType  : base.haxeType,
+      haxeType:  over.haxeType  != null ? over.haxeType  : base.haxeType,
       // L1 type is always "value", a Neko tagged pointer
       l1Type:   "value",
-      l2Type:    over != null && over.l2Type    != null ? over.l2Type    : base.l2Type,
-      l3Type:    over != null && over.l3Type    != null ? over.l3Type    : base.l3Type,
-      mangled:   over != null && over.mangled   != null ? over.mangled   : base.mangled,
-      l1l2:      over != null && over.l1l2      != null ? over.l1l2      : base.l1l2,
-      l2l3:      over != null && over.l2l3      != null ? over.l2l3      : base.l2l3,
-      l3l2:      over != null && over.l3l2      != null ? over.l3l2      : base.l3l2,
-      l2l1:      over != null && over.l2l1      != null ? over.l2l1      : base.l2l1,
-      arrayBits: over != null && over.arrayBits != null ? over.arrayBits : base.arrayBits,
-      arrayType: over != null && over.arrayType != null ? over.arrayType : base.arrayType,
+      l2Type:    over.l2Type    != null ? over.l2Type    : base.l2Type,
+      l3Type:    over.l3Type    != null ? over.l3Type    : base.l3Type,
+      mangled:   over.mangled   != null ? over.mangled   : base.mangled,
+      l1l2:      over.l1l2      != null ? over.l1l2      : base.l1l2,
+      l2l3:      over.l2l3      != null ? over.l2l3      : base.l2l3,
+      l3l2:      over.l3l2      != null ? over.l3l2      : base.l3l2,
+      l2l1:      over.l2l1      != null ? over.l2l1      : base.l2l1,
+      arrayBits: over.arrayBits != null ? over.arrayBits : base.arrayBits,
+      arrayType: over.arrayType != null ? over.arrayType : base.arrayType,
     };
   }
 
@@ -452,7 +452,7 @@ alloc_field($l1, _ammer_haxe_field_low, alloc_int32($l2 & 0xFFFFFFFF));',
   public function int64():NekoTypeMarshal return MARSHAL_INT64;
 
   public function enumInt(name:String, type:NekoTypeMarshal):NekoTypeMarshal
-    return baseExtend(BaseMarshal.baseEnumInt(name, type));
+    return baseExtend(BaseMarshal.baseEnumInt(name, type), {});
 
   static final MARSHAL_FLOAT32 = baseExtend(BaseMarshal.baseFloat64As32(), {
     l1l2: (l1, l2) -> '$l2 = val_number($l1);',

--- a/src/ammer/core/plat/Neko.hx
+++ b/src/ammer/core/plat/Neko.hx
@@ -451,6 +451,9 @@ alloc_field($l1, _ammer_haxe_field_low, alloc_int32($l2 & 0xFFFFFFFF));',
   public function uint64():NekoTypeMarshal return MARSHAL_UINT64;
   public function int64():NekoTypeMarshal return MARSHAL_INT64;
 
+  public function enumInt(name:String, type:NekoTypeMarshal):NekoTypeMarshal
+    return baseExtend(BaseMarshal.baseEnumInt(name, type));
+
   static final MARSHAL_FLOAT32 = baseExtend(BaseMarshal.baseFloat64As32(), {
     l1l2: (l1, l2) -> '$l2 = val_number($l1);',
     l2l1: (l2, l1) -> '$l1 = alloc_float($l2);',

--- a/src/ammer/core/plat/Nodejs.hx
+++ b/src/ammer/core/plat/Nodejs.hx
@@ -60,7 +60,7 @@ class Nodejs extends Base<
         ]
       ));
       ops.push(BODependent(
-        File('${config.outputPath}/${lib.config.name}.node'),
+        File('${config.outputPath}/${lib.outputPathRelative}'),
         File('${config.buildPath}/${lib.config.name}/build/Release/binding.node'),
         Copy
       ));
@@ -329,6 +329,7 @@ NAPI_MODULE_INIT() {
   _ammer_nodejs_env = env;
   return exports;
 }');
+    outputPathRelative = '${config.name}.node';
     super.finalise(platConfig);
   }
 

--- a/src/ammer/core/plat/Nodejs.hx
+++ b/src/ammer/core/plat/Nodejs.hx
@@ -498,25 +498,25 @@ class NodejsMarshal extends BaseMarshal<
 > {
   static function baseExtend(
     base:BaseTypeMarshal,
-    ?over:BaseTypeMarshal.BaseTypeMarshalOpt
+    over:BaseTypeMarshal.BaseTypeMarshalOpt
   ):NodejsTypeMarshal {
     return {
-      haxeType:  over != null && over.haxeType  != null ? over.haxeType  : base.haxeType,
+      haxeType:  over.haxeType  != null ? over.haxeType  : base.haxeType,
       // L1 type is always "napi_value", a Node.js tagged pointer (or boxed NaN)
       l1Type:   "napi_value",
-      l2Type:    over != null && over.l2Type    != null ? over.l2Type    : base.l2Type,
-      l3Type:    over != null && over.l3Type    != null ? over.l3Type    : base.l3Type,
-      mangled:   over != null && over.mangled   != null ? over.mangled   : base.mangled,
-      l1l2:      over != null && over.l1l2      != null ? over.l1l2      : base.l1l2,
-      l2l3:      over != null && over.l2l3      != null ? over.l2l3      : base.l2l3,
-      l3l2:      over != null && over.l3l2      != null ? over.l3l2      : base.l3l2,
-      l2l1:      over != null && over.l2l1      != null ? over.l2l1      : base.l2l1,
-      arrayBits: over != null && over.arrayBits != null ? over.arrayBits : base.arrayBits,
-      arrayType: over != null && over.arrayType != null ? over.arrayType : base.arrayType,
+      l2Type:    over.l2Type    != null ? over.l2Type    : base.l2Type,
+      l3Type:    over.l3Type    != null ? over.l3Type    : base.l3Type,
+      mangled:   over.mangled   != null ? over.mangled   : base.mangled,
+      l1l2:      over.l1l2      != null ? over.l1l2      : base.l1l2,
+      l2l3:      over.l2l3      != null ? over.l2l3      : base.l2l3,
+      l3l2:      over.l3l2      != null ? over.l3l2      : base.l3l2,
+      l2l1:      over.l2l1      != null ? over.l2l1      : base.l2l1,
+      arrayBits: over.arrayBits != null ? over.arrayBits : base.arrayBits,
+      arrayType: over.arrayType != null ? over.arrayType : base.arrayType,
     };
   }
 
-  static final MARSHAL_VOID = baseExtend(BaseMarshal.baseVoid());
+  static final MARSHAL_VOID = baseExtend(BaseMarshal.baseVoid(), {});
   public function void():NodejsTypeMarshal return MARSHAL_VOID;
 
   static final MARSHAL_BOOL = baseExtend(BaseMarshal.baseBool(), {
@@ -616,7 +616,7 @@ class NodejsMarshal extends BaseMarshal<
   public function int64():NodejsTypeMarshal return MARSHAL_INT64;
 
   public function enumInt(name:String, type:NodejsTypeMarshal):NodejsTypeMarshal
-    return baseExtend(BaseMarshal.baseEnumInt(name, type));
+    return baseExtend(BaseMarshal.baseEnumInt(name, type), {});
 
   static final MARSHAL_FLOAT32 = baseExtend(BaseMarshal.baseFloat64As32(), {
     l1l2: (l1, l2) -> 'NAPI_CALL_I(napi_get_value_double(_nodejs_env, $l1, &$l2));',

--- a/src/ammer/core/plat/Nodejs.hx
+++ b/src/ammer/core/plat/Nodejs.hx
@@ -614,6 +614,9 @@ class NodejsMarshal extends BaseMarshal<
   public function uint64():NodejsTypeMarshal return MARSHAL_UINT64;
   public function int64():NodejsTypeMarshal return MARSHAL_INT64;
 
+  public function enumInt(name:String, type:NodejsTypeMarshal):NodejsTypeMarshal
+    return baseExtend(BaseMarshal.baseEnumInt(name, type));
+
   static final MARSHAL_FLOAT32 = baseExtend(BaseMarshal.baseFloat64As32(), {
     l1l2: (l1, l2) -> 'NAPI_CALL_I(napi_get_value_double(_nodejs_env, $l1, &$l2));',
     l2l1: (l2, l1) -> 'NAPI_CALL_I(napi_create_double(_nodejs_env, $l2, &$l1));',

--- a/src/ammer/core/plat/None.hx
+++ b/src/ammer/core/plat/None.hx
@@ -115,6 +115,9 @@ class NoneMarshal extends BaseMarshal<
   public function uint64():NoneTypeMarshal return MARSHAL_UINT64;
   public function int64():NoneTypeMarshal return MARSHAL_INT64;
 
+  public function enumInt(name:String, type:NoneTypeMarshal):NoneTypeMarshal
+    return BaseMarshal.baseEnumInt(name, type);
+
   static final MARSHAL_FLOAT32 = BaseMarshal.baseFloat32();
   static final MARSHAL_FLOAT64 = BaseMarshal.baseFloat64();
   public function float32():NoneTypeMarshal return MARSHAL_FLOAT32;

--- a/src/ammer/core/plat/Python.hx
+++ b/src/ammer/core/plat/Python.hx
@@ -374,25 +374,25 @@ class PythonMarshal extends BaseMarshal<
 > {
   static function baseExtend(
     base:BaseTypeMarshal,
-    ?over:BaseTypeMarshal.BaseTypeMarshalOpt
+    over:BaseTypeMarshal.BaseTypeMarshalOpt
   ):PythonTypeMarshal {
     return {
-      haxeType:  over != null && over.haxeType  != null ? over.haxeType  : base.haxeType,
+      haxeType:  over.haxeType  != null ? over.haxeType  : base.haxeType,
       // L1 type is always "PyObject*", a Python object pointer
       l1Type:   "PyObject*",
-      l2Type:    over != null && over.l2Type    != null ? over.l2Type    : base.l2Type,
-      l3Type:    over != null && over.l3Type    != null ? over.l3Type    : base.l3Type,
-      mangled:   over != null && over.mangled   != null ? over.mangled   : base.mangled,
-      l1l2:      over != null && over.l1l2      != null ? over.l1l2      : base.l1l2,
-      l2l3:      over != null && over.l2l3      != null ? over.l2l3      : base.l2l3,
-      l3l2:      over != null && over.l3l2      != null ? over.l3l2      : base.l3l2,
-      l2l1:      over != null && over.l2l1      != null ? over.l2l1      : base.l2l1,
-      arrayBits: over != null && over.arrayBits != null ? over.arrayBits : base.arrayBits,
-      arrayType: over != null && over.arrayType != null ? over.arrayType : base.arrayType,
+      l2Type:    over.l2Type    != null ? over.l2Type    : base.l2Type,
+      l3Type:    over.l3Type    != null ? over.l3Type    : base.l3Type,
+      mangled:   over.mangled   != null ? over.mangled   : base.mangled,
+      l1l2:      over.l1l2      != null ? over.l1l2      : base.l1l2,
+      l2l3:      over.l2l3      != null ? over.l2l3      : base.l2l3,
+      l3l2:      over.l3l2      != null ? over.l3l2      : base.l3l2,
+      l2l1:      over.l2l1      != null ? over.l2l1      : base.l2l1,
+      arrayBits: over.arrayBits != null ? over.arrayBits : base.arrayBits,
+      arrayType: over.arrayType != null ? over.arrayType : base.arrayType,
     };
   }
 
-  static final MARSHAL_VOID = baseExtend(BaseMarshal.baseVoid());
+  static final MARSHAL_VOID = baseExtend(BaseMarshal.baseVoid(), {});
   public function void():PythonTypeMarshal return MARSHAL_VOID;
 
   static final MARSHAL_BOOL = baseExtend(BaseMarshal.baseBool(), {
@@ -463,7 +463,7 @@ class PythonMarshal extends BaseMarshal<
   public function int64():PythonTypeMarshal return MARSHAL_INT64;
 
   public function enumInt(name:String, type:PythonTypeMarshal):PythonTypeMarshal
-    return baseExtend(BaseMarshal.baseEnumInt(name, type));
+    return baseExtend(BaseMarshal.baseEnumInt(name, type), {});
 
   static final MARSHAL_FLOAT32 = baseExtend(BaseMarshal.baseFloat64As32(), {
     l1l2: (l1, l2) -> '$l2 = PyFloat_AsDouble($l1);',

--- a/src/ammer/core/plat/Python.hx
+++ b/src/ammer/core/plat/Python.hx
@@ -112,7 +112,7 @@ static PyObject* _ammer_python_fromhaxecopy(PyObject *_python_self, PyObject *_p
 static PyObject* _ammer_python_fromhaxeref(PyObject *_python_self, PyObject *_python_args) {
   Py_buffer* view = (Py_buffer*)${config.mallocFunction}(sizeof(Py_buffer));
   PyObject_GetBuffer(PyTuple_GetItem(_python_args, 0), view, PyBUF_C_CONTIGUOUS); // TODO: writable flag?
-  uint8_t* data = view->buf;
+  uint8_t* data = (uint8_t*)view->buf;
   return PyTuple_Pack(2,
     PyLong_FromUnsignedLongLong((uint64_t)view),
     PyLong_FromUnsignedLongLong((uint64_t)data)

--- a/src/ammer/core/plat/Python.hx
+++ b/src/ammer/core/plat/Python.hx
@@ -462,6 +462,9 @@ class PythonMarshal extends BaseMarshal<
   public function uint64():PythonTypeMarshal return MARSHAL_UINT64;
   public function int64():PythonTypeMarshal return MARSHAL_INT64;
 
+  public function enumInt(name:String, type:PythonTypeMarshal):PythonTypeMarshal
+    return baseExtend(BaseMarshal.baseEnumInt(name, type));
+
   static final MARSHAL_FLOAT32 = baseExtend(BaseMarshal.baseFloat64As32(), {
     l1l2: (l1, l2) -> '$l2 = PyFloat_AsDouble($l1);',
     l2l1: (l2, l1) -> '$l1 = PyFloat_FromDouble($l2);',

--- a/src/ammer/core/plat/Python.hx
+++ b/src/ammer/core/plat/Python.hx
@@ -33,10 +33,8 @@ class Python extends Base<
     return baseDynamicLinkProgram({
       includePaths: config.pythonIncludePaths,
       libraryPaths: config.pythonLibraryPaths,
-      defines: lib -> ["NDEBUG", "MAJOR_VERSION=1", "MINOR_VERSION=0"].concat(lib.config.defines),
+      defines: ["NDEBUG", "MAJOR_VERSION=1", "MINOR_VERSION=0"],
       linkNames: ['python3${BuildProgram.useMSVC ? "" : "."}${config.pythonVersionMinor}'],
-      // .so is intentional on macOS
-      outputPath: lib -> '${config.outputPath}/${lib.config.name}.${BuildProgram.useMSVC ? "pyd" : "so"}',
     });
   }
 }
@@ -215,6 +213,8 @@ PyMODINIT_FUNC PyInit_${config.name}(void) {
   };
   return PyModule_Create2(&_init_module, PYTHON_API_VERSION);
 }');
+    // .so is intentional on macOS
+    outputPathRelative = '${config.name}.${BuildProgram.useMSVC ? "pyd" : "so"}';
     super.finalise(platConfig);
   }
 


### PR DESCRIPTION
Summary of changes:

- Added `enumInt` marshal type for enumeration types.
- Added `outputPathRelative` to library API (used by `ammer`).
- Added `nullPtr` for array types.
- Added `LinkExecutable` build operation (used by `ammer` to obtain values of enums at compile time).
- Improved C++ compatibility for C#, Java, and Lua.
- Fixed some issues with callbacks on C# and Lua.
- Fixed C# strings.
- Various cleanups.